### PR TITLE
Add script to sync metadata label widths on mobile

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -497,6 +497,19 @@ function edpsy_enqueue_fix_tab_focus_script()
 }
 add_action('wp_enqueue_scripts', 'edpsy_enqueue_fix_tab_focus_script');
 
+// Match meta-item label widths on small screens
+function edpsy_enqueue_meta_label_resize_script()
+{
+    wp_enqueue_script(
+        'meta-label-resize',
+        get_template_directory_uri() . '/js/meta-label-resize.js',
+        array(),
+        null,
+        true // load in footer
+    );
+}
+add_action('wp_enqueue_scripts', 'edpsy_enqueue_meta_label_resize_script');
+
 add_filter('tribe_events_event_schedule_details_inner', 'edpsy_custom_time_range_in_brackets', 10, 2);
 
 function edpsy_custom_time_range_in_brackets($inner, $event_id)

--- a/js/meta-label-resize.js
+++ b/js/meta-label-resize.js
@@ -1,0 +1,26 @@
+(function() {
+  function adjustMetaLabelWidth() {
+    const labels = document.querySelectorAll('.meta-item .label');
+    if (!labels.length) return;
+
+    // Only apply on narrow viewports
+    if (window.innerWidth <= 782) {
+      let maxWidth = 0;
+      labels.forEach(label => {
+        label.style.width = 'auto';
+        const width = label.offsetWidth;
+        if (width > maxWidth) maxWidth = width;
+      });
+      labels.forEach(label => {
+        label.style.width = maxWidth + 'px';
+      });
+    } else {
+      labels.forEach(label => {
+        label.style.width = '';
+      });
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', adjustMetaLabelWidth);
+  window.addEventListener('resize', adjustMetaLabelWidth);
+})();


### PR DESCRIPTION
## Summary
- add `meta-label-resize.js` to align `.meta-item .label` widths on small viewports
- enqueue the new script in `functions.php`

## Testing
- `php -l functions.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a6670850c83258bf51ed06012034e