### PR TITLE
Render upcoming events on homepage using shared template

### DIFF
--- a/home.php
+++ b/home.php
@@ -265,35 +265,46 @@ $final_posts = get_posts(array(
 
 <section class="homepage-events-wrapper">
     <div class="homepage-events grid12">
-<h2>Next events</h2>
-<?php
-// Query the next 4 upcoming Tribe events
-$events = tribe_get_events( array(
-    'posts_per_page' => 4,
-    'start_date'     => date( 'Y-m-d H:i:s' ),
-    'orderby'        => 'event_date',
-    'order'          => 'ASC',
-) );
-
-if ( $events ) :
-    echo '<ul class="homepage-upcoming-events">';
-    foreach ( $events as $event ) :
-        $event_id = $event->ID;
-        $event_title = get_the_title( $event_id );
-        $event_link = get_permalink( $event_id );
-        $event_date = tribe_get_start_date( $event_id, false, 'F j, Y g:i a' );
-        ?>
-        <li>
-            <a href="<?php echo esc_url( $event_link ); ?>"><?php echo esc_html( $event_title ); ?></a><br>
-            <small><?php echo esc_html( $event_date ); ?></small>
-        </li>
+        <h2>Next events</h2>
         <?php
-    endforeach;
-    echo '</ul>';
-else :
-    echo '<p>No upcoming events found.</p>';
-endif;
-?>
+        // Query the next 4 upcoming Tribe events
+        $events = tribe_get_events([
+                'posts_per_page' => 4,
+                'start_date'     => date('Y-m-d H:i:s'),
+                'orderby'        => 'event_date',
+                'order'          => 'ASC',
+        ]);
+
+        if ($events) :
+                if (!class_exists('EDP_Tribe_Template')) {
+                        class EDP_Tribe_Template {
+                                public function template($template, $data = []) {
+                                        $path = locate_template('tribe/events/v2/' . $template . '.php');
+                                        if (!$path) {
+                                                return;
+                                        }
+                                        extract($data);
+                                        include $path;
+                                }
+                        }
+                }
+
+                $tpl = new EDP_Tribe_Template();
+                echo '<div class="edp-events-calendar-list">';
+                foreach ($events as $event_post) {
+                        $event = tribe_get_event($event_post);
+                        $tpl->template('list/event', [
+                                'event'        => $event,
+                                'is_past'      => false,
+                                'request_date' => null,
+                                'slug'         => 'home',
+                        ]);
+                }
+                echo '</div>';
+        else :
+                echo '<p>No upcoming events found.</p>';
+        endif;
+        ?>
     </div>
 </section>
 

--- a/tests/event-template-render.php
+++ b/tests/event-template-render.php
@@ -1,0 +1,66 @@
+<?php
+// Minimal environment to render event template and ensure nested templates receive data.
+
+// Stub WordPress and TEC functions used in templates.
+function tribe_get_post_class($classes, $post_id) {
+    $classes[] = 'post-' . $post_id;
+    return $classes;
+}
+function tribe_classes($classes) {
+    echo 'class="' . esc_attr(implode(' ', array_filter($classes))) . '"';
+}
+function esc_url($url) { return $url; }
+function esc_html($text) { return htmlspecialchars($text, ENT_QUOTES, 'UTF-8'); }
+function esc_attr($text) { return htmlspecialchars($text, ENT_QUOTES, 'UTF-8'); }
+function esc_html_x($text) { return esc_html($text); }
+function do_action($hook, ...$args) { /* no-op for test */ }
+
+// Minimal DateTime utilities used by date-tag template.
+class Stub_DateTime extends DateTime {
+    public function format_i18n($format) { return $this->format($format); }
+}
+class Tribe__Date_Utils {
+    const DBDATEFORMAT = 'Y-m-d H:i:s';
+}
+
+// Simple collection to mimic TEC venue collection.
+class VenueCollection implements Countable, ArrayAccess {
+    private $venues = [];
+    public function __construct($venues) { $this->venues = $venues; }
+    public function count(): int { return count($this->venues); }
+    public function offsetExists($offset): bool { return isset($this->venues[$offset]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset) { return $this->venues[$offset]; }
+    public function offsetSet($offset, $value): void { $this->venues[$offset] = $value; }
+    public function offsetUnset($offset): void { unset($this->venues[$offset]); }
+}
+
+// Template loader mimicking TEC's $this->template() behaviour.
+class EDP_Tribe_Template {
+    public function template($template, $data = []) {
+        $path = __DIR__ . '/../tribe/events/v2/' . $template . '.php';
+        if (!file_exists($path)) {
+            return;
+        }
+        extract($data);
+        include $path;
+    }
+}
+
+// Build a fake event object with minimal properties used by templates.
+$event = (object) [
+    'ID'        => 1,
+    'title'     => 'Sample Event',
+    'permalink' => 'https://example.com/event',
+    'featured'  => false,
+    'dates'     => (object) [ 'start_display' => new Stub_DateTime('2030-01-02 10:00:00') ],
+    'venues'    => new VenueCollection([(object) ['post_title' => 'Online', 'city' => 'London']]),
+];
+
+$tpl = new EDP_Tribe_Template();
+$tpl->template('list/event', [
+    'event'        => $event,
+    'is_past'      => false,
+    'request_date' => null,
+    'slug'         => 'test',
+]);

--- a/tribe/events/v2/list/event.php
+++ b/tribe/events/v2/list/event.php
@@ -12,7 +12,11 @@
  *
  * @version 5.0.0
  *
- * @var WP_Post $event The event post object with properties added by the `tribe_get_event` function.
+ * @var WP_Post            $event        The event post object with properties added by the `tribe_get_event` function.
+ * @var \DateTimeInterface $request_date The request date object. This will be "today" if the user did not input any
+ *                                       date, or the user input date.
+ * @var bool               $is_past      Whether the current display mode is "past" or not.
+ * @var string             $slug         The slug of the current view.
  *
  * @see tribe_get_event() For the format of the event object.
  */
@@ -39,10 +43,14 @@ foreach ($event_classes as $class) {
 
 
 		<?php if ($is_on_demand): ?>
-		<?php $this->template('list/event/ondemand-tag') ?>
-	<?php else: ?>
-		<?php $this->template('list/event/date-tag', ['event' => $event]); ?>
-<?php endif; ?>
+                <?php $this->template('list/event/ondemand-tag'); ?>
+        <?php else: ?>
+                <?php $this->template('list/event/date-tag', [
+                        'event'        => $event,
+                        'request_date' => $request_date,
+                        'is_past'      => $is_past,
+                ]); ?>
+        <?php endif; ?>
 
 
 		<div class="edp-events-calendar-list__event-header">
@@ -59,7 +67,10 @@ foreach ($event_classes as $class) {
 							</span>
 						</address>
 					<?php else: ?>
-						<?php $this->template('list/event/venue', ['event' => $event]); ?>
+                                                <?php $this->template('list/event/venue', [
+                                                        'event' => $event,
+                                                        'slug'  => $slug,
+                                                ]); ?>
 					<?php endif; ?>
 			
 			<?php $this->template('list/event/cost', ['event' => $event]); ?>


### PR DESCRIPTION
## Summary
- Render next four events on the homepage using the `tribe/events/v2/list/event.php` override so styles stay consistent with the main events listing.
- Expand the event override to forward `request_date`, `is_past`, and `slug` to nested templates, ensuring date and venue templates receive their required data.
- Add a small CLI test script that simulates event data to verify template rendering.

## Testing
- `php -l home.php`
- `php -l tribe/events/v2/list/event.php`
- `php -l tests/event-template-render.php`
- `php tests/event-template-render.php`


------
https://chatgpt.com/codex/tasks/task_e_688faa560ed08325b09f12a6db951149