### PR TITLE
Add count class to homepage events wrapper

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -413,6 +413,10 @@ function edp_customize_register($wp_customize) {
 }
 add_action('customize_register', 'edp_customize_register');
 
+function edpsybold_count_class($count) {
+    return 'edp-bold-posts-' . intval($count);
+}
+
 // ========== Jobs homepage shortcode =========== //
 
 // Register [jobs-homepage] shortcode with count-based CSS class
@@ -433,7 +437,7 @@ function wpjm_jobs_homepage_shortcode($atts) {
     $job_count = $jobs->found_posts;
 
     if ( $jobs->have_posts() ) {
-        $count_class = 'edp-bold-posts-' . $job_count;
+        $count_class = edpsybold_count_class($job_count);
         echo '<div class="jobs-homepage-grid ' . esc_attr($count_class) . '">';
         while ( $jobs->have_posts() ) {
             $jobs->the_post();

--- a/home.php
+++ b/home.php
@@ -263,18 +263,22 @@ $final_posts = get_posts(array(
 <?php echo do_shortcode('[jobs-homepage per_page="3" show_filters="false"]') ?>
 </section>
 
-<section class="homepage-events-wrapper">
+<?php
+// Query the next 4 upcoming Tribe events
+$events = tribe_get_events([
+        'posts_per_page' => 4,
+        'start_date'     => date('Y-m-d H:i:s'),
+        'orderby'        => 'event_date',
+        'order'          => 'ASC',
+]);
+
+$event_count = count($events);
+$count_class = edpsybold_count_class($event_count);
+?>
+<section class="homepage-events-wrapper <?php echo esc_attr($count_class); ?>">
     <div class="homepage-events grid12">
         <h2>Next events</h2>
         <?php
-        // Query the next 4 upcoming Tribe events
-        $events = tribe_get_events([
-                'posts_per_page' => 4,
-                'start_date'     => date('Y-m-d H:i:s'),
-                'orderby'        => 'event_date',
-                'order'          => 'ASC',
-        ]);
-
         if ($events) :
                 if (!class_exists('EDP_Tribe_Template')) {
                         class EDP_Tribe_Template {


### PR DESCRIPTION
## Summary
- add helper to generate `edp-bold-posts-*` count classes
- apply count class to homepage events wrapper based on fetched event total
- reuse helper in jobs shortcode to consolidate logic

## Testing
- `php tests/event-template-render.php`

------
https://chatgpt.com/codex/tasks/task_e_6898d195500c8325ad54ea17597af0da