### PR TITLE
Fix on-demand event category class on home page

### DIFF
--- a/tests/event-template-render.php
+++ b/tests/event-template-render.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ERROR | E_PARSE);
 // Minimal environment to render event template and ensure nested templates receive data.
 
 // Stub WordPress and TEC functions used in templates.
@@ -14,6 +15,11 @@ function esc_html($text) { return htmlspecialchars($text, ENT_QUOTES, 'UTF-8'); 
 function esc_attr($text) { return htmlspecialchars($text, ENT_QUOTES, 'UTF-8'); }
 function esc_html_x($text) { return esc_html($text); }
 function do_action($hook, ...$args) { /* no-op for test */ }
+function is_front_page() { return false; }
+function is_home() { return false; }
+function has_term($term, $taxonomy, $post_id) {
+    return $term === 'on-demand';
+}
 
 // Minimal DateTime utilities used by date-tag template.
 class Stub_DateTime extends DateTime {
@@ -58,6 +64,7 @@ $event = (object) [
 ];
 
 $tpl = new EDP_Tribe_Template();
+$event_date_attr = '';
 $tpl->template('list/event', [
     'event'        => $event,
     'is_past'      => false,

--- a/tribe/events/v2/list/event.php
+++ b/tribe/events/v2/list/event.php
@@ -26,15 +26,24 @@ $container_classes['edp-events-calendar-list__event-row--featured'] = $event->fe
 
 $event_classes = tribe_get_post_class(['tribe-events-calendar-list__event', 'tribe-common-g-row', 'tribe-common-g-row--gutters'], $event->ID);
 ?>
-<!-- Adds ondemand tag --> 
+<!-- Adds ondemand tag -->
 <?php
-$is_on_demand = false;
-foreach ($event_classes as $class) {
-	if (strpos($class, 'cat_on-demand') !== false) {
-		$is_on_demand = true;
-		$container_classes[] = 'cat_on-demand';
-		break;
-	}
+/**
+ * Determine whether the event belongs to the "on-demand" category. When
+ * rendering on the home page the event's classes do not include category
+ * information, so we use `has_term` to perform the check.
+ */
+$is_on_demand = function_exists('has_term') && has_term('on-demand', 'tribe_events_cat', $event->ID);
+if (!$is_on_demand) {
+        foreach ($event_classes as $class) {
+                if (strpos($class, 'cat_on-demand') !== false) {
+                        $is_on_demand = true;
+                        break;
+                }
+        }
+}
+if ($is_on_demand) {
+        $container_classes[] = 'cat_on-demand';
 }
 ?>
 <div <?php tribe_classes($container_classes); ?>>


### PR DESCRIPTION
## Summary
- Ensure events tagged "on-demand" receive the `cat_on-demand` class even when rendered on the home page
- Add stub functions in test harness for home page and taxonomy detection

## Testing
- `php tests/event-template-render.php`

------
https://chatgpt.com/codex/tasks/task_e_6898dbbbb148832589b6778a3371a240