### PR TITLE
Wrap homepage events in row wrappers

### DIFF
--- a/home.php
+++ b/home.php
@@ -292,7 +292,12 @@ $count_class = edpsybold_count_class($event_count);
                         }
                 };
 
+                $event_index = 0;
                 foreach ($events as $event_post) {
+                        if ($event_index % 2 === 0) {
+                                echo '<div class="edp-events-calendar-list__event-row-wrapper">';
+                        }
+
                         $event = tribe_get_event($event_post);
                         $tpl->template('list/event', [
                                 'event'        => $event,
@@ -300,6 +305,11 @@ $count_class = edpsybold_count_class($event_count);
                                 'request_date' => null,
                                 'slug'         => 'home',
                         ]);
+
+                        $event_index++;
+                        if ($event_index % 2 === 0 || $event_index === $event_count) {
+                                echo '</div>';
+                        }
                 }
                 echo '</div>';
         else :


### PR DESCRIPTION
## Summary
- group homepage events in pairs within `edp-events-calendar-list__event-row-wrapper` containers

## Testing
- `php -l home.php`
- `php tests/event-template-render.php`

------
https://chatgpt.com/codex/tasks/task_e_6898e3bd3aa08325b91ad20334185e9f