### PR TITLE
Enable hover dropdown for main navigation

### DIFF
--- a/css/parts/header.css
+++ b/css/parts/header.css
@@ -86,6 +86,20 @@ header[role="banner"] {
                     display: flex;
                 }
 
+                @media screen and (min-width: 701px) {
+                    ul.sub-menu {
+                        position: absolute;
+                        top: 100%;
+                        left: 0;
+                        background-color: var(--cl-light);
+                        z-index: 1000;
+                    }
+
+                    &:hover>ul.sub-menu {
+                        display: flex;
+                    }
+                }
+
                 button.submenu-toggle {
                     display: none;
 


### PR DESCRIPTION
## Summary
- Show submenu items below their parent on hover for wide screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aae03a503c8325a80f15918a8a438e