### PR TITLE
Hide jobs heading when no listings

### DIFF
--- a/home.php
+++ b/home.php
@@ -258,10 +258,15 @@ $final_posts = get_posts(array(
     </section>
 <?php endif; ?>
 <div class="home-divider grid12"></div>
+<?php
+$homepage_jobs_output = do_shortcode('[jobs-homepage per_page="3" show_filters="false"]');
+if (trim($homepage_jobs_output) !== '') :
+?>
 <section class="homepage-jobs grid12">
 <h2>Jobs</h2>
-<?php echo do_shortcode('[jobs-homepage per_page="3" show_filters="false"]') ?>
+<?php echo $homepage_jobs_output; ?>
 </section>
+<?php endif; ?>
 
 <?php
 // Query the next 4 upcoming events


### PR DESCRIPTION
## Summary
- only show Jobs section on homepage when listings exist

## Testing
- `php tests/event-template-render.php`

------
https://chatgpt.com/codex/tasks/task_e_68ab2b025e648325bf0633160920c67a