### PR TITLE
Add native share button using Web Share API

### DIFF
--- a/entry-meta.php
+++ b/entry-meta.php
@@ -1,3 +1,4 @@
+
 <!-- file: entry-meta.php -->
 
 <div class="meta-bg"></div>
@@ -33,13 +34,7 @@ if ($tags && ! is_wp_error($tags)) {
 }
 ?>
             </div>
-<button type="button"
-        id="share-button"
-        class="share-button button edp-button"
-        data-title="<?php echo esc_attr(get_the_title()); ?>"
-        data-url="<?php echo esc_url(get_permalink()); ?>"
-        data-text="<?php echo esc_attr(strip_tags(get_the_excerpt())); ?>"
-        data-image="<?php echo esc_url(get_the_post_thumbnail_url(null, 'full')); ?>">
-    <?php esc_html_e('Share', 'edpsybold'); ?>
+<button type="button" id="share-button" class="edp-button-solid">
+    <?php esc_html_e('share', 'edpsybold'); ?>
 </button>
 <!-- file end: entry-meta.php -->

--- a/entry-meta.php
+++ b/entry-meta.php
@@ -33,8 +33,13 @@ if ($tags && ! is_wp_error($tags)) {
 }
 ?>
             </div>
-
-<div class="share-button button edp-button">
-    SHAREBUTTON
-            </div>
+<button type="button"
+        id="share-button"
+        class="share-button button edp-button"
+        data-title="<?php echo esc_attr(get_the_title()); ?>"
+        data-url="<?php echo esc_url(get_permalink()); ?>"
+        data-text="<?php echo esc_attr(strip_tags(get_the_excerpt())); ?>"
+        data-image="<?php echo esc_url(get_the_post_thumbnail_url(null, 'full')); ?>">
+    <?php esc_html_e('Share', 'edpsybold'); ?>
+</button>
 <!-- file end: entry-meta.php -->

--- a/functions.php
+++ b/functions.php
@@ -37,6 +37,13 @@ function edpsybold_enqueue()
 {
     wp_enqueue_style('edpsybold-style', get_stylesheet_uri());
     wp_enqueue_script('jquery');
+    wp_enqueue_script(
+        'edpsybold-share',
+        get_template_directory_uri() . '/js/share.js',
+        array(),
+        filemtime(get_template_directory() . '/js/share.js'),
+        true
+    );
 }
 add_action('wp_footer', 'edpsybold_footer');
 function edpsybold_footer()

--- a/js/share.js
+++ b/js/share.js
@@ -14,35 +14,17 @@
       return;
     }
 
-    btn.addEventListener('click', async function (e) {
+    btn.addEventListener('click', function (e) {
       e.preventDefault();
       var shareData = {
-        title: btn.dataset.title || document.title,
-        text: btn.dataset.text || '',
-        url: btn.dataset.url || window.location.href
+        title: document.title,
+        url: window.location.href
       };
-
-      var imgUrl = btn.dataset.image;
-      if (navigator.canShare && imgUrl) {
-        try {
-          var response = await fetch(imgUrl, { mode: 'cors' });
-          var blob = await response.blob();
-          var file = new File([blob], 'share.' + (blob.type.split('/').pop() || 'jpg'), { type: blob.type });
-          if (navigator.canShare({ files: [file] })) {
-            shareData.files = [file];
-          }
-        } catch (err) {
-          // Ignore image errors and share without image
-          console.error('Image fetch failed', err);
-        }
-      }
-
-      try {
-        await navigator.share(shareData);
-      } catch (err) {
+      navigator.share(shareData).catch(function (err) {
         // User may cancel share or share may fail; log for debugging
         console.error('Share failed', err);
-      }
+      });
     });
   });
 })();
+

--- a/js/share.js
+++ b/js/share.js
@@ -1,0 +1,48 @@
+// Native share button functionality
+// Uses the Web Share API when available
+
+(function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    var btn = document.getElementById('share-button');
+    if (!btn) {
+      return;
+    }
+
+    if (!navigator.share) {
+      // Hide the button if Web Share API is not supported
+      btn.style.display = 'none';
+      return;
+    }
+
+    btn.addEventListener('click', async function (e) {
+      e.preventDefault();
+      var shareData = {
+        title: btn.dataset.title || document.title,
+        text: btn.dataset.text || '',
+        url: btn.dataset.url || window.location.href
+      };
+
+      var imgUrl = btn.dataset.image;
+      if (navigator.canShare && imgUrl) {
+        try {
+          var response = await fetch(imgUrl, { mode: 'cors' });
+          var blob = await response.blob();
+          var file = new File([blob], 'share.' + (blob.type.split('/').pop() || 'jpg'), { type: blob.type });
+          if (navigator.canShare({ files: [file] })) {
+            shareData.files = [file];
+          }
+        } catch (err) {
+          // Ignore image errors and share without image
+          console.error('Image fetch failed', err);
+        }
+      }
+
+      try {
+        await navigator.share(shareData);
+      } catch (err) {
+        // User may cancel share or share may fail; log for debugging
+        console.error('Share failed', err);
+      }
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- replace placeholder with sanitized Share button and metadata
- enqueue and implement Web Share API script for native sharing

## Testing
- `php -l entry-meta.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7004da6f8832589755ba96928b9c5