### PR TITLE
Add job title support for coauthors

### DIFF
--- a/biography.php
+++ b/biography.php
@@ -19,6 +19,15 @@ if (function_exists('coauthors_posts_links')) {
 
             <div class="author-description">
                 <h2 class="author-title">About <span class="author-heading"><?php echo $coauthor->display_name; ?></h2>
+                <?php
+                if (is_a($coauthor, 'WP_User')) {
+                    $job_title = get_user_meta($coauthor->ID, 'job_title', true);
+                } else {
+                    $job_title = get_post_meta($coauthor->ID, 'job_title', true);
+                }
+                if ($job_title) : ?>
+                    <div class="author-job-title"><?php echo esc_html($job_title); ?></div>
+                <?php endif; ?>
 
                 <p class="author-bio">
                     <?php echo $coauthor->description; ?>

--- a/entry-author.php
+++ b/entry-author.php
@@ -47,6 +47,32 @@
                         }
                         ?>
                     </div><!-- .author-names -->
+                    <?php
+                    $job_titles = array();
+                    foreach ($coauthors as $coauthor) {
+                        if (is_a($coauthor, 'WP_User')) {
+                            $job_title = get_user_meta($coauthor->ID, 'job_title', true);
+                        } else {
+                            $job_title = get_post_meta($coauthor->ID, 'job_title', true);
+                        }
+                        if ($job_title) {
+                            $job_titles[] = '<span class="author-heading">' . esc_html($job_title) . '</span>';
+                        }
+                    }
+                    if (!empty($job_titles)) {
+                        echo '<div class="author-job-title">';
+                        $jt_count = count($job_titles);
+                        if ($jt_count == 2) {
+                            echo implode('<br> & ', $job_titles);
+                        } elseif ($jt_count > 2) {
+                            $last_job = array_pop($job_titles);
+                            echo implode(',<br> ', $job_titles) . '<br>& ' . $last_job;
+                        } else {
+                            echo $job_titles[0];
+                        }
+                        echo '</div>';
+                    }
+                    ?>
                 </div><!-- .authors-section -->
             <?php endif;
         }

--- a/functions.php
+++ b/functions.php
@@ -708,6 +708,48 @@ function my_co_author_wseo_title($title)
 
 }
 
+// ========== Co-authors job title field ==================================== //
+// ======================================================================== //
+
+// Add job title field to guest author edit screen
+add_filter('coauthors_guest_author_fields', 'edpsybold_add_guest_author_job_title_field');
+function edpsybold_add_guest_author_job_title_field($fields)
+{
+    $fields['job_title'] = array(
+        'key'   => 'job_title',
+        'label' => __('Job title', 'edpsybold'),
+        'type'  => 'text',
+    );
+    return $fields;
+}
+
+// Add job title field to user profile
+add_action('show_user_profile', 'edpsybold_user_job_title_profile_field');
+add_action('edit_user_profile', 'edpsybold_user_job_title_profile_field');
+function edpsybold_user_job_title_profile_field($user)
+{
+    ?>
+    <h3><?php esc_html_e('Job title', 'edpsybold'); ?></h3>
+    <table class="form-table">
+        <tr>
+            <th><label for="job_title"><?php esc_html_e('Job title', 'edpsybold'); ?></label></th>
+            <td>
+                <input type="text" name="job_title" id="job_title" value="<?php echo esc_attr(get_user_meta($user->ID, 'job_title', true)); ?>" class="regular-text" />
+            </td>
+        </tr>
+    </table>
+    <?php
+}
+
+add_action('personal_options_update', 'edpsybold_save_user_job_title_profile_field');
+add_action('edit_user_profile_update', 'edpsybold_save_user_job_title_profile_field');
+function edpsybold_save_user_job_title_profile_field($user_id)
+{
+    if (current_user_can('edit_user', $user_id) && isset($_POST['job_title'])) {
+        update_user_meta($user_id, 'job_title', sanitize_text_field($_POST['job_title']));
+    }
+}
+
 // ========== Job manager ================================================= //
 // ======================================================================== //
 


### PR DESCRIPTION
## Summary
- add Job title field for co-authors and user profiles
- display author job titles on posts and in author biographies

## Testing
- `php -l functions.php`
- `php -l entry-author.php`
- `php -l biography.php`
- `php -l tests/event-template-render.php`


------
https://chatgpt.com/codex/tasks/task_e_68b71c1ed4a4832586e5a20f5c1613e8