### PR TITLE
style: add interest group page styling

### DIFF
--- a/css/edpsy-bold-style.css
+++ b/css/edpsy-bold-style.css
@@ -11,6 +11,7 @@
 @import url('parts/events.css');
 @import url('parts/jobs.css');
 @import url('parts/thesis.css');
+@import url('parts/interest-groups.css');
 @import url('parts/page-single-listing.css');
 @import url('parts/home.css');
 @import url('parts/footer.css');

--- a/css/parts/interest-groups.css
+++ b/css/parts/interest-groups.css
@@ -1,0 +1,46 @@
+@import url('variables.css');
+
+.category-groups {
+    #container {
+        background-color: var(--cl-lightblue);
+        background-image: url(../../images/edpsy-swirls-28.svg);
+        background-size: 400px;
+        background-position: top right;
+        background-repeat: no-repeat;
+    }
+
+    .entry-content {
+        ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: grid;
+            gap: var(--sp-small);
+        }
+
+        li {
+            background-color: var(--cl-light);
+            border: 1px solid var(--cl-dark-50);
+            border-radius: var(--rd-small);
+            padding: var(--sp-small);
+
+            &:hover {
+                background-color: var(--cl-light-75);
+            }
+
+            h4 {
+                margin: 0;
+                font-weight: var(--fw-medium);
+            }
+
+            a {
+                color: var(--cl-dark);
+                text-decoration: none;
+
+                &:hover {
+                    color: var(--cl-dark-hover);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated styling for Interest Groups page
- import new stylesheet in main theme CSS

## Testing
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbcf3cb083258363b94e2bba3c2e