### PR TITLE
Add body menu state classes

### DIFF
--- a/css/parts/grid.css
+++ b/css/parts/grid.css
@@ -45,6 +45,19 @@
     }
 }
 
+@media only screen and (max-width: 700px) {
+    .grid12 {
+        .menu-toggle {
+            grid-column: 11 / span 2;
+            justify-self: end;
+        }
+
+        nav.top-nav-menu {
+            grid-column: 1 / span 12;
+        }
+    }
+}
+
 /* === Page ===================== */
 
 .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page {

--- a/css/parts/header.css
+++ b/css/parts/header.css
@@ -20,6 +20,14 @@ header[role="banner"] {
         opacity: var(--op-light);
     }
 
+    .menu-toggle {
+        display: none;
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+    }
+
     nav.top-nav-menu {
         height: 100%;
 
@@ -203,4 +211,27 @@ body {
         }
     }
 
+}
+
+@media screen and (max-width: 700px) {
+    header[role="banner"] {
+        .menu-toggle {
+            display: block;
+        }
+
+        nav.top-nav-menu {
+            grid-column: 1 / span 12;
+
+            ul {
+                flex-direction: column;
+                align-items: flex-start;
+                width: 100%;
+                display: none;
+            }
+
+            &.open ul {
+                display: flex;
+            }
+        }
+    }
 }

--- a/functions.php
+++ b/functions.php
@@ -497,6 +497,28 @@ function edpsy_enqueue_fix_tab_focus_script()
 }
 add_action('wp_enqueue_scripts', 'edpsy_enqueue_fix_tab_focus_script');
 
+// Mobile menu toggle script
+function edpsy_enqueue_mobile_menu_script()
+{
+    wp_enqueue_script(
+        'mobile-menu',
+        get_template_directory_uri() . '/js/mobile-menu.js',
+        array('jquery'),
+        null,
+        true
+    );
+}
+add_action('wp_enqueue_scripts', 'edpsy_enqueue_mobile_menu_script');
+
+// Default mobile menu state on body element
+function edpsy_add_menu_state_body_class($classes)
+{
+    $classes[] = 'menu-closed';
+
+    return $classes;
+}
+add_filter('body_class', 'edpsy_add_menu_state_body_class');
+
 function edpsy_custom_time_range_in_brackets($inner, $event_id)
 {
     $event = get_post($event_id);

--- a/header.php
+++ b/header.php
@@ -47,6 +47,7 @@
                     <?php bloginfo('description'); ?>
                 </div> -->
 
+                <button class="menu-toggle" aria-label="Toggle menu"><i class="far fa-bars"></i></button>
                 <nav class="top-nav-menu">
                     <?php
                     wp_nav_menu(array(

--- a/js/mobile-menu.js
+++ b/js/mobile-menu.js
@@ -1,0 +1,17 @@
+jQuery(function ($) {
+    var body = $('body');
+
+    $('.menu-toggle').on('click', function () {
+        var nav = $('.top-nav-menu');
+        var icon = $(this).find('i');
+
+        nav.toggleClass('open');
+
+        var isOpen = nav.hasClass('open');
+
+        icon.toggleClass('fa-bars', !isOpen).toggleClass('fa-times', isOpen);
+
+        body.toggleClass('menu-on', isOpen);
+        body.toggleClass('menu-closed', !isOpen);
+    });
+});


### PR DESCRIPTION
## Summary
- add a default `menu-closed` class to the body element
- toggle `menu-on` and `menu-closed` body classes alongside the icon change

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_687242db47488325953609afad4072e8