### PR TITLE
Add legacy CSS fallback for non-nesting browsers

### DIFF
--- a/css/edpsy-bold-style--legacy.css
+++ b/css/edpsy-bold-style--legacy.css
@@ -1,0 +1,6223 @@
+@import url('fontawesome/all.css');
+
+html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font-style: inherit;
+    font-variant: inherit;
+    font-weight: inherit;
+    font-stretch: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    font-family: inherit;
+}
+
+a {
+    text-decoration-skip-ink: auto;
+    position: relative;
+}
+
+a[href^="tel"] {
+    color: inherit;
+}
+
+button {
+    outline: 0;
+    border: 0;
+    padding: 0;
+    background-color: inherit;
+    font-family: var(--ff);
+}
+
+blockquote:before, blockquote:after, q:before, q:after {
+    content: '';
+}
+
+q {
+    display: inline;
+}
+
+q:before {
+    content: '"';
+}
+
+q:after {
+    content: '"';
+}
+
+textarea, input[type="text"], input[type="button"], input[type="submit"], input[type="reset"], input[type="search"], input[type="password"] {
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+kbd, tt {
+    font-family: courier;
+}
+
+address {
+    font-style: normal;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+.screen-reader-text {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    -webkit-clip-path: inset(50%);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute !important;
+    width: 1px;
+    word-wrap: normal !important;
+}
+
+.screen-reader-text:focus {
+    background-color: #f7f7f7;
+    border-radius: 3px;
+    box-shadow: 0 0 2px 2px rgba(0, 0, 0, .6);
+    clip: auto !important;
+    -webkit-clip-path: none;
+    clip-path: none;
+    color: #007acc;
+    display: block;
+    font-size: 14px;
+    font-size: .875rem;
+    font-weight: 700;
+    height: auto;
+    right: 5px;
+    line-height: normal;
+    padding: 15px 23px 14px;
+    text-decoration: none;
+    top: 5px;
+    width: auto;
+}
+
+.skip-link {
+    left: -9999rem;
+    top: 2.5rem;
+    z-index: 999999999;
+}
+
+.skip-link:focus {
+    display: block;
+    left: 6px;
+    top: 7px;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    line-height: normal;
+    padding: 15px 23px 14px;
+    z-index: 100000;
+    right: auto;
+}
+
+.visually-hidden:not(:focus):not(:active), .form-allowed-tags:not(:focus):not(:active) {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px);
+}
+
+#tribe-events-pg-template {
+    padding: 0;
+    margin: 0;
+}
+
+.tribe-common--breakpoint-medium.tribe-events .tribe-events-l-container {
+    padding: 0;
+}
+
+.tribe-common--breakpoint-medium.tribe-common .tribe-common-c-btn-border-small, .tribe-common--breakpoint-medium.tribe-common a.tribe-common-c-btn-border-small {
+    padding: inherit;
+    width: inherit;
+}
+
+.tribe-events .tribe-events-header {
+    flex-direction: initial;
+    flex-wrap: nowrap;
+    margin: 0;
+    padding: 0;
+    position: relative;
+}
+
+.datepicker table tr td.active, .datepicker table tr td.active.disabled, .datepicker table tr td.active.disabled:hover, .datepicker table tr td.active:hover, .datepicker table tr td span.active, .datepicker table tr td span.active.disabled, .datepicker table tr td span.active.disabled:hover, .datepicker table tr td span.active:hover {
+    background-image: none;
+    background-color: inherit;
+}
+
+.tribe-common--breakpoint-medium.tribe-events .tribe-events-calendar-list__event-cost, .tribe-events .tribe-events-calendar-list__event-date-tag-weekday, .tribe-events-calendar-list__event-date-tag-datetime, .tribe-events-calendar-list__event-date-tag, .tribe-events .tribe-events-calendar-list__event-title-link:visited {
+    margin-top: inherit;
+    margin-bottom: inherit;
+    padding: 0;
+    color: inherit;
+}
+
+.wpbdp-page input[type="email"], .wpbdp-form-field input[type="email"], .wpbdp-single input[type="email"], .wpbdp-excerpt input[type="email"], .wpbdp-page input[type="number"], .wpbdp-form-field input[type="number"], .wpbdp-single input[type="number"], .wpbdp-excerpt input[type="number"], .wpbdp-page input[type="password"], .wpbdp-form-field input[type="password"], .wpbdp-single input[type="password"], .wpbdp-excerpt input[type="password"], .wpbdp-page input[type="search"], .wpbdp-form-field input[type="search"], .wpbdp-single input[type="search"], .wpbdp-excerpt input[type="search"], .wpbdp-page input[type="tel"], .wpbdp-form-field input[type="tel"], .wpbdp-single input[type="tel"], .wpbdp-excerpt input[type="tel"], .wpbdp-page input[type="text"], .wpbdp-form-field input[type="text"], .wpbdp-single input[type="text"], .wpbdp-excerpt input[type="text"], .wpbdp-page input[type="url"], .wpbdp-form-field input[type="url"], .wpbdp-single input[type="url"], .wpbdp-excerpt input[type="url"], .wpbdp-page textarea, .wpbdp-form-field textarea, .wpbdp-single textarea, .wpbdp-excerpt textarea, .wpbdp-page select, .wpbdp-form-field select, .wpbdp-single select, .wpbdp-excerpt select, .wpbdp-page .select2 .select2-selection, .wpbdp-form-field .select2 .select2-selection, .wpbdp-single .select2 .select2-selection, .wpbdp-excerpt .select2 .select2-selection {
+    all: inherit;
+}
+
+@font-face {
+    font-family: "Geologica";
+        src: url("../../fonts/geologica.ttf") format("truetype");
+        font-weight: 100 900;
+        font-style: normal;
+}
+
+:root {
+    --cl-light: #FFFBF2;
+    --cl-light-75: #fffbf2b4;
+    --cl-light-50: #fffbf27a;
+    --cl-light-15: #fffbf226;
+    --cl-dark: #363033;
+    --cl-dark-plus: #242022;
+    --cl-dark-hover: #534E50;
+    --cl-dark-75: rgba(54, 48, 51, 0.75);
+    --cl-dark-50: rgba(54, 48, 51, 0.5);
+    --cl-link: #0072B9;
+    --cl-straw: #FFF4DA;
+    --cl-straw-75: #fff4dabf;
+    --cl-orange: #DB633B;
+    --cl-red: #db4b3b;
+    --cl-red-25: #db4b3b43;
+    --cl-lightblue: #78A8CF;
+    --cl-green: #5EA259;
+    --cl-yellow: #E5C957;
+    --cl-purple: #59408A;
+    --cl-medpurple: #A359A2;
+    --cl-medpurple-hover: #B07DB2;
+    --cl-lightpurple: #BF86A7;
+    --cl-lightpurple-hover: rgba(228, 212, 228);
+    --cl-thesis-primary: var(--cl-lightblue);
+    --cl-blog-primary: var(--cl-medpurple);
+    --cl-events-primary: var(--cl-dark);
+    --cl-jobs-primary: var(--cl-orange);
+    --op-light: 0.8;
+    --op-strong: 0.6;
+    --sp-neg-xsmall: -6px;
+    --sp-neg-small: -12px;
+    --sp-neg-small-plus: -18px;
+    --sp-neg-medium: -24px;
+    --sp-neg-large: -36px;
+    --sp-neg-xlarge: -48px;
+    --sp-neg-xxlarge: -60px;
+    --sp-neg-xxxlarge: -72px;
+    --sp-neg-xxxxlarge: -100px;
+    --sp-xxsmall: 3px;
+    --sp-xsmall: 6px;
+    --sp-small: 12px;
+    --sp-small-plus: 18px;
+    --sp-medium: 24px;
+    --sp-large: 36px;
+    --sp-xlarge: 48px;
+    --sp-xxlarge: 60px;
+    --sp-xxxlarge: 72px;
+    --sp-home-gap: var(--sp-medium);
+    --rd-small: 6px;
+    --rd-large: 10px;
+    --tb-xxsmall: 100px;
+    --tb-xsmall: 150px;
+    --tb-small: 240px;
+    --tb-medium: 386px;
+    --tb-large: 520px;
+    --lv-full-width: 1248px;
+    --lv-listing-height: 140px;
+    --ff: 'Geologica', sans-serif;
+    --fs-body-small: 14px;
+    --fs-body-medium: 16px;
+    --fs-body: 18px;
+    --fs-title-small: 22px;
+    --fs-title-smallmedium: 26px;
+    --fs-title-medium: 28px;
+    --fs-title-large: 35px;
+    --fs-title-xlarge: 40px;
+    --fs-display-large: 110px;
+    --fs-display-medium: 60px;
+    --fs-display-small: 45px;
+    --lh-body-small: calc(var(--fs-body-small) * 1.15);
+    --lh-body: calc(var(--fs-body) * 1.5);
+    --lh-title-small: calc(var(--fs-title-small) * 1.15);
+    --lh-title-smallmedium: calc(var(--fs-title-smallmedium) * 1.15);
+    --lh-title-medium: calc(var(--fs-title-medium) * 1.15);
+    --lh-title-large: calc(var(--fs-title-large) * 1.15);
+    --lh-title-xlarge: calc(var(--fs-title-xlarge) * 1.15);
+    --lh-display-large: calc(var(--fs-display-large) * 1.15);
+    --lh-display-medium: calc(var(--fs-display-medium) * 1.15);
+    --lh-display-smallmedium: calc(var(--fs-display-smallmedium) * 1.15);
+    --lh-display-small: calc(var(--fs-display-small) * 1.15);
+    --fw-thin: 100;
+    --fw-extralight: 200;
+    --fw-light: 300;
+    --fw-normal: 400;
+    --fw-medium: 500;
+    --fw-semibold: 600;
+    --aspect-ratio-landscape: 16/9;
+    --bp-small: 480px;
+    --bp-medium: 768px;
+    --bp-large: 1024px;
+    --bp-xlarge: 1281px;
+    --gs-3: calc(3 * ((100% / 10) - (2 * 24px)) + (3 * 24px));
+    --gs-8: calc((8 * ((100vw - 144px - (11 * 24px)) / 12)) + (7 * 24px));
+    --gs-10: calc((10 * ((100vw - 144px - (11 * 24px)) / 12)) + (9 * 24px));
+    --gs-12: calc(((100vw - 144px - (11 * 24px))) + (11 * 24px));
+}
+
+.edp-thesis-abstract {
+    --cl-primary: var(--cl-thesis-primary);
+}
+
+.entry-content {
+    --cl-primary: var(--cl-blog-primary);
+}
+
+.tribe-events-content {
+    --cl-primary: var(--cl-events-primary);
+}
+
+.edp-jobs {
+    --cl-primary: var(--cl-jobs-primary);
+}
+
+.tribe-events script {
+    display: none;
+}
+
+.post-edit-link {
+    display: none;
+}
+
+#menu {
+    display: none;
+}
+
+body {
+    font-family: var(--ff);
+    color: var(--cl-dark);
+    font-size: var(--fs-body);
+    font-weight: var(--fw-extralight);
+    line-height: var(--lh-body);
+    margin-top: 10px;
+    background-color: var(--cl-light);
+    margin: 0 auto;
+}
+
+a:link, a:visited, a:hover, a:active {
+    color: var(--cl-link);
+    text-decoration: none;
+}
+
+p {
+    margin-bottom: var(--sp-medium);
+    font-size: var(--fs-body);
+}
+
+strong, b, .body-emphasis {
+    font-weight: var(--fw-semibold);
+}
+
+.edp-bg-dark a:is(:link, :visited) {
+    text-decoration: underline;
+}
+
+.edp-bg-dark a:is(:hover, :active) {
+    text-decoration: none;
+}
+
+.edp-bg-dark a {
+    color: var(--cl-light);
+}
+
+.edp-fullwidth {
+    width: 100%;
+    padding: 0 var(--sp-medium);
+}
+
+.edp-pagewidth {
+    width: var(--lv-full-width);
+    margin: 0 max(4vw, var(--sp-small));
+}
+
+.grid12>* {
+    grid-column: 2 / span 10;
+}
+
+.grid12 #site-title {
+    grid-column: 1 / span 2;
+    height: 68.83px;
+}
+
+.grid12 .backblock-link {
+    grid-column: 1 / span 12;
+}
+
+.grid12 nav.top-nav-menu {
+    grid-column: 3 / span 10;
+}
+
+.grid12 {
+    grid-template-columns: repeat(12, 1fr);
+    display: grid;
+    grid-column-gap: 24px;
+    max-width: var(--lv-full-width);
+    margin: 0 auto;
+}
+
+.home .grid12>* {
+    grid-column: 1 / span 12;
+}
+
+.page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page>* {
+    grid-column: 1 / span 8;
+}
+
+.page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page .entry-content {
+    grid-column: 1 / span 8;
+}
+
+.page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 3 / span 8;
+}
+
+.crp_related {
+    grid-column: 1 / span 12;
+}
+
+.archive.category-blog .grid12:is(article.post) {
+    grid-column: 3 / span 8;
+}
+
+.archive.category-blog .grid12 header {
+    grid-column: 1 / span 12;
+}
+
+.archive.author .archive-meta {
+    display: grid;
+    grid-template-columns: subgrid;
+}
+
+body.single-post article.type-post h1.entry-title {
+    grid-column: 2 / span 8;
+}
+
+body.single-post article.type-post .author-image-header-block .meta-bg {
+    grid-column: 1 / span 1;
+}
+
+body.single-post article.type-post .author-image-header-block .entry-meta {
+    grid-column: 10 / span 2;
+}
+
+body.single-post article.type-post .author-image-header-block .entry-image {
+    grid-column: 2 / span 7;
+}
+
+body.single-post article.type-post .author-image-header-block {
+    grid-column: 1 / span 12;
+}
+
+body.single-post article.type-post .entry-content h2, body.single-post article.type-post .entry-content h3, body.single-post article.type-post .entry-content h4, body.single-post article.type-post .entry-content h5, body.single-post article.type-post .entry-content h6, body.single-post article.type-post .entry-content p, body.single-post article.type-post .entry-content ul, body.single-post article.type-post .entry-content ol, body.single-post article.type-post .entry-content blockquote, body.single-post article.type-post .entry-content .content-body {
+    grid-column: 3 / span 6;
+}
+
+body.single-post article.type-post .entry-content .entry-author--top {
+    grid-column: 9 / span 3;
+}
+
+body.single-post article.type-post .entry-footer .cat-links, body.single-post article.type-post .entry-footer .tag-links {
+    grid-column: 3 / span 7;
+}
+
+body.single-post article.type-post .entry-footer .page-divider {
+    grid-column: 1 / span 12;
+}
+
+body.single-post article.type-post .entry-footer header.header {
+    grid-column: 1 / span 12;
+}
+
+body.single-post article.type-post .entry-footer .author-info .author-avatar {
+    grid-column: 1 / span 2;
+}
+
+body.single-post article.type-post .entry-footer .author-info .author-description {
+    grid-column: 3 / span 7;
+}
+
+body.single-post article.type-post .entry-footer .author-info {
+    display: grid;
+    grid-template-columns: subgrid;
+}
+
+.archive.author header.header {
+    grid-column: 1 / span 12;
+}
+
+.archive.author .author-info .author-avatar {
+    min-width: 173px;
+    padding-left: var(--sp-medium);
+    padding-right: var(--sp-medium);
+}
+
+.archive.author .author-info .author-description {
+    padding-right: var(--sp-large);
+}
+
+.archive.author .author-info {
+    grid-column: 1 / span 10;
+    display: flex;
+}
+
+body.single-post article.type-post .entry-footer .author-info {
+    grid-column: 1 / span 10;
+}
+
+.archive .author-info {
+    grid-column: 1 / span 10;
+}
+
+.archive.author .author-info {
+    grid-column: 1 / span 10;
+}
+
+.post-type-archive-tribe_events .tribe-events-view--month {
+    grid-column: 1 / span 12;
+}
+
+.tribe-events-view--list>* {
+    grid-column: 2 / span 10;
+}
+
+.tribe-events-view--list .tribe-events-l-container>* {
+    grid-column: 2 / span 10;
+}
+
+.tribe-events-view--list .tribe-events-l-container {
+    grid-column: 1 / span 12;
+    display: grid;
+    grid-template-columns: subgrid;
+}
+
+.tribe-events-view--list .tribe-events-header {
+    grid-column: 1 / span 12;
+}
+
+.tribe-events-view--list .tribe-events-header__top-bar {
+    grid-column: 2 / span 10;
+}
+
+.tribe-events-view--list .tribe-events-calendar-list {
+    grid-column: 2 / span 10;
+}
+
+.tribe-events-view--list {
+    grid-column: 1 / span 12;
+    display: grid;
+    grid-template-columns: subgrid;
+}
+
+.tribe_community_edit .tribe-events-pg-template {
+    grid-column: 2 / span 10;
+}
+
+.single-tribe_events article.tribe-events-single .tribe-events-after-html .event-disclaimer {
+    grid-column: 2 / span 8;
+}
+
+.single-tribe_events article.tribe-events-single .tribe-events-venue-map {
+    grid-column: 1 / span 12;
+}
+
+.job-listings-page:is(article.page), .add-job:is(article.page) {
+    grid-column: 1 / span 12;
+}
+
+.add-job article.category-jobs-admin header {
+    grid-column: 1 / span 12;
+}
+
+.add-job article.category-jobs-admin>* {
+    grid-column: 2 / span 10;
+}
+
+.add-job article.category-jobs-admin {
+    grid-column: 1 / span 12;
+    display: grid;
+    grid-template-columns: subgrid;
+}
+
+.single-tribe_events article.tribe-events-single>*, .single-tribe_events article.type-job_listing>*, .single-tribe_events article.wpbdp_listing>*, .single-job-listing article.tribe-events-single>*, .single-job-listing article.type-job_listing>*, .single-job-listing article.wpbdp_listing>*, .single-wpbdp_listing article.tribe-events-single>*, .single-wpbdp_listing article.type-job_listing>*, .single-wpbdp_listing article.wpbdp_listing>*, .job_listing_preview article.tribe-events-single>*, .job_listing_preview article.type-job_listing>*, .job_listing_preview article.wpbdp_listing>* {
+    grid-column: 3 / span 8;
+}
+
+.single-tribe_events article.tribe-events-single header, .single-tribe_events article.type-job_listing header, .single-tribe_events article.wpbdp_listing header, .single-job-listing article.tribe-events-single header, .single-job-listing article.type-job_listing header, .single-job-listing article.wpbdp_listing header, .single-wpbdp_listing article.tribe-events-single header, .single-wpbdp_listing article.type-job_listing header, .single-wpbdp_listing article.wpbdp_listing header, .job_listing_preview article.tribe-events-single header, .job_listing_preview article.type-job_listing header, .job_listing_preview article.wpbdp_listing header {
+    display: grid;
+    grid-column: 2 / span 10;
+}
+
+.single-tribe_events article.tribe-events-single .meta-slice .meta-img-l, .single-tribe_events article.type-job_listing .meta-slice .meta-img-l, .single-tribe_events article.wpbdp_listing .meta-slice .meta-img-l, .single-job-listing article.tribe-events-single .meta-slice .meta-img-l, .single-job-listing article.type-job_listing .meta-slice .meta-img-l, .single-job-listing article.wpbdp_listing .meta-slice .meta-img-l, .single-wpbdp_listing article.tribe-events-single .meta-slice .meta-img-l, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-l, .single-wpbdp_listing article.wpbdp_listing .meta-slice .meta-img-l, .job_listing_preview article.tribe-events-single .meta-slice .meta-img-l, .job_listing_preview article.type-job_listing .meta-slice .meta-img-l, .job_listing_preview article.wpbdp_listing .meta-slice .meta-img-l {
+    grid-column: 1 / span 3;
+}
+
+.single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta, .single-job-listing article.tribe-events-single .meta-slice .job-listing-meta, .single-job-listing article.tribe-events-single .meta-slice .event-listing-meta, .single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta, .single-job-listing article.type-job_listing .meta-slice .job-listing-meta, .single-job-listing article.type-job_listing .meta-slice .event-listing-meta, .single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta, .single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta, .single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta, .single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta, .job_listing_preview article.tribe-events-single .meta-slice .job-listing-meta, .job_listing_preview article.tribe-events-single .meta-slice .event-listing-meta, .job_listing_preview article.tribe-events-single .meta-slice .edp-thesis-meta, .job_listing_preview article.type-job_listing .meta-slice .job-listing-meta, .job_listing_preview article.type-job_listing .meta-slice .event-listing-meta, .job_listing_preview article.type-job_listing .meta-slice .edp-thesis-meta, .job_listing_preview article.wpbdp_listing .meta-slice .job-listing-meta, .job_listing_preview article.wpbdp_listing .meta-slice .event-listing-meta, .job_listing_preview article.wpbdp_listing .meta-slice .edp-thesis-meta {
+    grid-column: 4 / span 6;
+}
+
+.single-tribe_events article.tribe-events-single .meta-slice .meta-img-r, .single-tribe_events article.type-job_listing .meta-slice .meta-img-r, .single-tribe_events article.wpbdp_listing .meta-slice .meta-img-r, .single-job-listing article.tribe-events-single .meta-slice .meta-img-r, .single-job-listing article.type-job_listing .meta-slice .meta-img-r, .single-job-listing article.wpbdp_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.tribe-events-single .meta-slice .meta-img-r, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.wpbdp_listing .meta-slice .meta-img-r, .job_listing_preview article.tribe-events-single .meta-slice .meta-img-r, .job_listing_preview article.type-job_listing .meta-slice .meta-img-r, .job_listing_preview article.wpbdp_listing .meta-slice .meta-img-r {
+    grid-column: 10 / span 3;
+}
+
+.single-tribe_events article.tribe-events-single .meta-slice, .single-tribe_events article.type-job_listing .meta-slice, .single-tribe_events article.wpbdp_listing .meta-slice, .single-job-listing article.tribe-events-single .meta-slice, .single-job-listing article.type-job_listing .meta-slice, .single-job-listing article.wpbdp_listing .meta-slice, .single-wpbdp_listing article.tribe-events-single .meta-slice, .single-wpbdp_listing article.type-job_listing .meta-slice, .single-wpbdp_listing article.wpbdp_listing .meta-slice, .job_listing_preview article.tribe-events-single .meta-slice, .job_listing_preview article.type-job_listing .meta-slice, .job_listing_preview article.wpbdp_listing .meta-slice {
+    grid-column: 1 / span 12;
+    display: grid;
+    grid-template-columns: subgrid;
+}
+
+.single-tribe_events article.tribe-events-single .job_description, .single-tribe_events article.type-job_listing .job_description, .single-tribe_events article.wpbdp_listing .job_description, .single-job-listing article.tribe-events-single .job_description, .single-job-listing article.type-job_listing .job_description, .single-job-listing article.wpbdp_listing .job_description, .single-wpbdp_listing article.tribe-events-single .job_description, .single-wpbdp_listing article.type-job_listing .job_description, .single-wpbdp_listing article.wpbdp_listing .job_description, .job_listing_preview article.tribe-events-single .job_description, .job_listing_preview article.type-job_listing .job_description, .job_listing_preview article.wpbdp_listing .job_description {
+    grid-column: 3 / span 8;
+}
+
+.single-tribe_events article.tribe-events-single .job-listing-logo, .single-tribe_events article.type-job_listing .job-listing-logo, .single-tribe_events article.wpbdp_listing .job-listing-logo, .single-job-listing article.tribe-events-single .job-listing-logo, .single-job-listing article.type-job_listing .job-listing-logo, .single-job-listing article.wpbdp_listing .job-listing-logo, .single-wpbdp_listing article.tribe-events-single .job-listing-logo, .single-wpbdp_listing article.type-job_listing .job-listing-logo, .single-wpbdp_listing article.wpbdp_listing .job-listing-logo, .job_listing_preview article.tribe-events-single .job-listing-logo, .job_listing_preview article.type-job_listing .job-listing-logo, .job_listing_preview article.wpbdp_listing .job-listing-logo {
+    grid-column: 8 / span 3;
+}
+
+.single-tribe_events .job-footer-contents, .single-job-listing .job-footer-contents, .single-wpbdp_listing .job-footer-contents, .job_listing_preview .job-footer-contents {
+    grid-column: 3 / span 8;
+}
+
+.wpbdp-view-main:is(article.page) header {
+    grid-column: 1 / span 12;
+}
+
+.wpbdp-view-main:is(article.page)>* {
+    grid-column: 2 / span 10;
+}
+
+.wpbdp-view-main:is(article.page) {
+    grid-column: 1 / span 12;
+    grid-template-columns: subgrid;
+    display: grid;
+}
+
+.footer-container.grid12>img {
+    grid-column: 1 / span 2;
+}
+
+.footer-container .footer-content {
+    grid-column: 3 / span 8;
+}
+
+.footer-container .footer-right {
+    grid-column: 11 / span 2;
+}
+
+.span10 {
+    grid-column: 2 / span 10;
+}
+
+.span8 {
+    grid-column: 3 / span 8;
+}
+
+header[role="banner"] .grid12 {
+    align-items: center;
+}
+
+header[role="banner"] h1 {
+    line-height: 0;
+}
+
+header[role="banner"] .header-logo-wrapper {
+    display: inline-block;
+}
+
+header[role="banner"] .header-logo-wrapper img {
+    display: block;
+}
+
+header[role="banner"] .header-logo {
+    width: 48px;
+}
+
+header[role="banner"] a:hover .header-logo {
+    opacity: var(--op-light);
+}
+
+header[role="banner"] .menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+header[role="banner"] nav.top-nav-menu ul>li a {
+    color: var(--cl-dark);
+    height: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--sp-xsmall);
+    padding: var(--sp-medium);
+    padding-right: calc(var(--sp-medium) + 2px);
+    padding-bottom: calc(var(--sp-medium) - 2px);
+    border-bottom: 3px solid var(--cl-light);
+}
+
+header[role="banner"] nav.top-nav-menu ul>li .submenu-wrapper {
+    display: flex;
+    width: 100%;
+}
+
+header[role="banner"] nav.top-nav-menu ul>li.current-menu-parent a, header[role="banner"] nav.top-nav-menu ul>li a:hover, header[role="banner"] nav.top-nav-menu ul>li.current-menu-item a {
+    border-bottom: 3px solid var(--cl-dark);
+}
+
+header[role="banner"] nav.top-nav-menu ul>li ul.sub-menu {
+    display: none;
+    flex-direction: column;
+    width: max-content;
+    min-width: 100%;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+header[role="banner"] nav.top-nav-menu ul>li.submenu-open>ul.sub-menu {
+    display: flex;
+}
+
+header[role="banner"] nav.top-nav-menu ul>li button.submenu-toggle:is(:hover, :active) {
+    background-color: var(--cl-lightpurple-hover);
+}
+
+header[role="banner"] nav.top-nav-menu ul>li button.submenu-toggle {
+    display: none;
+    font-size: 1.3rem;
+    background: none;
+    border: none;
+    padding: 0 var(--sp-medium);
+    cursor: pointer;
+    border-left: 1px solid var(--cl-dark);
+}
+
+header[role="banner"] nav.top-nav-menu ul>li {
+    position: relative;
+    font-size: var(--fs-body-small);
+    font-weight: var(--fw-semibold);
+    color: var(--cl-dark);
+    cursor: pointer;
+    transition: background-color 0.3s;
+    display: flex;
+}
+
+header[role="banner"] nav.top-nav-menu ul {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+header[role="banner"] nav.top-nav-menu {
+    height: 100%;
+}
+
+header[role="banner"] {
+    border-bottom: 1px solid var(--cl-dark);
+}
+
+body .backblock a:hover, body .backblock a:focus {
+    background-color: var(--cl-light-15);
+}
+
+body .backblock a {
+    border-radius: var(--rd-small);
+    margin-left: -8px;
+    padding: 2px var(--sp-xsmall);
+}
+
+body .backblock {
+    padding-top: var(--sp-small);
+    padding-bottom: var(--sp-small);
+}
+
+.home header[role="banner"] .header-logo-wrapper:hover .header-logo, .home header[role="banner"] .header-logo-wrapper:active .header-logo {
+    opacity: 1;
+}
+
+.home header[role="banner"] .header-logo-wrapper .header-logo {
+    width: 110px;
+    background-color: var(--cl-light);
+    padding: var(--sp-small-plus);
+    margin: 0;
+}
+
+.home header[role="banner"] .header-logo-wrapper {
+    padding: var(--sp-small) 0;
+}
+
+.home header[role="banner"] {
+    border-bottom: none;
+}
+
+.single-post header[role="banner"], .edp-parent-mentoring header[role="banner"], .edp-parent-interest-groups header[role="banner"] {
+    border-bottom: none;
+}
+
+.single-post .backblock a:hover, .edp-parent-mentoring .backblock a:hover, .edp-parent-interest-groups .backblock a:hover {
+    color: var(--cl-dark);
+    background-color: var(--cl-lightpurple-hover);
+}
+
+.single-post .backblock a, .edp-parent-mentoring .backblock a, .edp-parent-interest-groups .backblock a {
+    color: var(--cl-dark);
+}
+
+.single-post .backblock, .edp-parent-mentoring .backblock, .edp-parent-interest-groups .backblock {
+    background-color: var(--cl-light);
+    border-top: 1px solid var(--cl-dark);
+    border-bottom: 1px solid var(--cl-dark);
+}
+
+.post-type-archive-tribe_events header[role="banner"] {
+    border-bottom: none;
+}
+
+.single-tribe_events header[role="banner"] {
+    border-bottom: none;
+}
+
+.single-tribe_events .backblock a:hover {
+    color: var(--cl-light);
+}
+
+.single-tribe_events .backblock a {
+    color: var(--cl-light);
+}
+
+.single-tribe_events .backblock {
+    background-color: var(--cl-events-primary);
+}
+
+.job-listings-page header[role="banner"] {
+    border-bottom: var(--cl-light);
+}
+
+.single-job_listing header[role="banner"] {
+    border-bottom: none;
+}
+
+.single-job_listing .backblock {
+    background-color: var(--cl-jobs-primary);
+}
+
+.wpbdp-view-main header[role="banner"] {
+    border-bottom: var(--cl-light);
+}
+
+.single-wpbdp_listing header[role="banner"] {
+    border-bottom: none;
+}
+
+.single-wpbdp_listing .backblock {
+    background-color: var(--cl-lightblue);
+}
+
+.navigation.posts-navigation .nav-links {
+    display: flex;
+    justify-content: space-between;
+}
+
+.navigation.posts-navigation {
+    margin-bottom: var(--sp-xxxlarge);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page img.wp-post-image, article.job_listing img.wp-post-image, article.tribe-events-single img.wp-post-image, body:not(.home) article.type-post img.wp-post-image, article.type-wpbdp_listing img.wp-post-image, .tribe-events-pg-template img.wp-post-image, .edp-jobs.add-job img.wp-post-image {
+    width: 100%;
+    height: auto;
+    margin-bottom: var(--sp-medium);
+    border-radius: var(--rd-large);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .wp-block-media-text__media img, article.job_listing .wp-block-media-text__media img, article.tribe-events-single .wp-block-media-text__media img, body:not(.home) article.type-post .wp-block-media-text__media img, article.type-wpbdp_listing .wp-block-media-text__media img, .tribe-events-pg-template .wp-block-media-text__media img, .edp-jobs.add-job .wp-block-media-text__media img {
+    border-radius: var(--rd-large);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .is-stacked-on-mobile figure, article.job_listing .is-stacked-on-mobile figure, article.tribe-events-single .is-stacked-on-mobile figure, body:not(.home) article.type-post .is-stacked-on-mobile figure, article.type-wpbdp_listing .is-stacked-on-mobile figure, .tribe-events-pg-template .is-stacked-on-mobile figure, .edp-jobs.add-job .is-stacked-on-mobile figure {
+    align-self: flex-start;
+    margin-bottom: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .wp-block-columns-is-layout-flex, article.job_listing .wp-block-columns-is-layout-flex, article.tribe-events-single .wp-block-columns-is-layout-flex, body:not(.home) article.type-post .wp-block-columns-is-layout-flex, article.type-wpbdp_listing .wp-block-columns-is-layout-flex, .tribe-events-pg-template .wp-block-columns-is-layout-flex, .edp-jobs.add-job .wp-block-columns-is-layout-flex {
+    gap: var(--sp-home-gap);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .wp-block-image figure.alignright, article.job_listing .wp-block-image figure.alignright, article.tribe-events-single .wp-block-image figure.alignright, body:not(.home) article.type-post .wp-block-image figure.alignright, article.type-wpbdp_listing .wp-block-image figure.alignright, .tribe-events-pg-template .wp-block-image figure.alignright, .edp-jobs.add-job .wp-block-image figure.alignright {
+    margin-left: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .wp-block-image, article.job_listing .wp-block-image, article.tribe-events-single .wp-block-image, body:not(.home) article.type-post .wp-block-image, article.type-wpbdp_listing .wp-block-image, .tribe-events-pg-template .wp-block-image, .edp-jobs.add-job .wp-block-image {
+    margin-bottom: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content ul li, .page-template-default:not(.job-listings-page) article.type-page .job_description ul li, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content ul li, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract ul li, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ul li, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration ul li, .page-template-default:not(.job-listings-page) article.type-page .events-promo ul li, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ul li, article.job_listing .entry-content ul li, article.job_listing .job_description ul li, article.job_listing .tribe-events-content ul li, article.job_listing .edp-thesis-abstract ul li, article.job_listing .category-jobs-admin ul li, article.job_listing fieldset.fieldset-cap_declaration ul li, article.job_listing .events-promo ul li, article.job_listing .category-jobs-admin ul li, article.tribe-events-single .entry-content ul li, article.tribe-events-single .job_description ul li, article.tribe-events-single .tribe-events-content ul li, article.tribe-events-single .edp-thesis-abstract ul li, article.tribe-events-single .category-jobs-admin ul li, article.tribe-events-single fieldset.fieldset-cap_declaration ul li, article.tribe-events-single .events-promo ul li, article.tribe-events-single .category-jobs-admin ul li, body:not(.home) article.type-post .entry-content ul li, body:not(.home) article.type-post .job_description ul li, body:not(.home) article.type-post .tribe-events-content ul li, body:not(.home) article.type-post .edp-thesis-abstract ul li, body:not(.home) article.type-post .category-jobs-admin ul li, body:not(.home) article.type-post fieldset.fieldset-cap_declaration ul li, body:not(.home) article.type-post .events-promo ul li, body:not(.home) article.type-post .category-jobs-admin ul li, article.type-wpbdp_listing .entry-content ul li, article.type-wpbdp_listing .job_description ul li, article.type-wpbdp_listing .tribe-events-content ul li, article.type-wpbdp_listing .edp-thesis-abstract ul li, article.type-wpbdp_listing .category-jobs-admin ul li, article.type-wpbdp_listing fieldset.fieldset-cap_declaration ul li, article.type-wpbdp_listing .events-promo ul li, article.type-wpbdp_listing .category-jobs-admin ul li, .tribe-events-pg-template .entry-content ul li, .tribe-events-pg-template .job_description ul li, .tribe-events-pg-template .tribe-events-content ul li, .tribe-events-pg-template .edp-thesis-abstract ul li, .tribe-events-pg-template .category-jobs-admin ul li, .tribe-events-pg-template fieldset.fieldset-cap_declaration ul li, .tribe-events-pg-template .events-promo ul li, .tribe-events-pg-template .category-jobs-admin ul li, .edp-jobs.add-job .entry-content ul li, .edp-jobs.add-job .job_description ul li, .edp-jobs.add-job .tribe-events-content ul li, .edp-jobs.add-job .edp-thesis-abstract ul li, .edp-jobs.add-job .category-jobs-admin ul li, .edp-jobs.add-job fieldset.fieldset-cap_declaration ul li, .edp-jobs.add-job .events-promo ul li, .edp-jobs.add-job .category-jobs-admin ul li {
+    list-style-type: disc;
+    margin-left: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content ul, .page-template-default:not(.job-listings-page) article.type-page .job_description ul, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content ul, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract ul, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ul, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration ul, .page-template-default:not(.job-listings-page) article.type-page .events-promo ul, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ul, article.job_listing .entry-content ul, article.job_listing .job_description ul, article.job_listing .tribe-events-content ul, article.job_listing .edp-thesis-abstract ul, article.job_listing .category-jobs-admin ul, article.job_listing fieldset.fieldset-cap_declaration ul, article.job_listing .events-promo ul, article.job_listing .category-jobs-admin ul, article.tribe-events-single .entry-content ul, article.tribe-events-single .job_description ul, article.tribe-events-single .tribe-events-content ul, article.tribe-events-single .edp-thesis-abstract ul, article.tribe-events-single .category-jobs-admin ul, article.tribe-events-single fieldset.fieldset-cap_declaration ul, article.tribe-events-single .events-promo ul, article.tribe-events-single .category-jobs-admin ul, body:not(.home) article.type-post .entry-content ul, body:not(.home) article.type-post .job_description ul, body:not(.home) article.type-post .tribe-events-content ul, body:not(.home) article.type-post .edp-thesis-abstract ul, body:not(.home) article.type-post .category-jobs-admin ul, body:not(.home) article.type-post fieldset.fieldset-cap_declaration ul, body:not(.home) article.type-post .events-promo ul, body:not(.home) article.type-post .category-jobs-admin ul, article.type-wpbdp_listing .entry-content ul, article.type-wpbdp_listing .job_description ul, article.type-wpbdp_listing .tribe-events-content ul, article.type-wpbdp_listing .edp-thesis-abstract ul, article.type-wpbdp_listing .category-jobs-admin ul, article.type-wpbdp_listing fieldset.fieldset-cap_declaration ul, article.type-wpbdp_listing .events-promo ul, article.type-wpbdp_listing .category-jobs-admin ul, .tribe-events-pg-template .entry-content ul, .tribe-events-pg-template .job_description ul, .tribe-events-pg-template .tribe-events-content ul, .tribe-events-pg-template .edp-thesis-abstract ul, .tribe-events-pg-template .category-jobs-admin ul, .tribe-events-pg-template fieldset.fieldset-cap_declaration ul, .tribe-events-pg-template .events-promo ul, .tribe-events-pg-template .category-jobs-admin ul, .edp-jobs.add-job .entry-content ul, .edp-jobs.add-job .job_description ul, .edp-jobs.add-job .tribe-events-content ul, .edp-jobs.add-job .edp-thesis-abstract ul, .edp-jobs.add-job .category-jobs-admin ul, .edp-jobs.add-job fieldset.fieldset-cap_declaration ul, .edp-jobs.add-job .events-promo ul, .edp-jobs.add-job .category-jobs-admin ul {
+    margin-left: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content ol li, .page-template-default:not(.job-listings-page) article.type-page .job_description ol li, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content ol li, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract ol li, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ol li, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration ol li, .page-template-default:not(.job-listings-page) article.type-page .events-promo ol li, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ol li, article.job_listing .entry-content ol li, article.job_listing .job_description ol li, article.job_listing .tribe-events-content ol li, article.job_listing .edp-thesis-abstract ol li, article.job_listing .category-jobs-admin ol li, article.job_listing fieldset.fieldset-cap_declaration ol li, article.job_listing .events-promo ol li, article.job_listing .category-jobs-admin ol li, article.tribe-events-single .entry-content ol li, article.tribe-events-single .job_description ol li, article.tribe-events-single .tribe-events-content ol li, article.tribe-events-single .edp-thesis-abstract ol li, article.tribe-events-single .category-jobs-admin ol li, article.tribe-events-single fieldset.fieldset-cap_declaration ol li, article.tribe-events-single .events-promo ol li, article.tribe-events-single .category-jobs-admin ol li, body:not(.home) article.type-post .entry-content ol li, body:not(.home) article.type-post .job_description ol li, body:not(.home) article.type-post .tribe-events-content ol li, body:not(.home) article.type-post .edp-thesis-abstract ol li, body:not(.home) article.type-post .category-jobs-admin ol li, body:not(.home) article.type-post fieldset.fieldset-cap_declaration ol li, body:not(.home) article.type-post .events-promo ol li, body:not(.home) article.type-post .category-jobs-admin ol li, article.type-wpbdp_listing .entry-content ol li, article.type-wpbdp_listing .job_description ol li, article.type-wpbdp_listing .tribe-events-content ol li, article.type-wpbdp_listing .edp-thesis-abstract ol li, article.type-wpbdp_listing .category-jobs-admin ol li, article.type-wpbdp_listing fieldset.fieldset-cap_declaration ol li, article.type-wpbdp_listing .events-promo ol li, article.type-wpbdp_listing .category-jobs-admin ol li, .tribe-events-pg-template .entry-content ol li, .tribe-events-pg-template .job_description ol li, .tribe-events-pg-template .tribe-events-content ol li, .tribe-events-pg-template .edp-thesis-abstract ol li, .tribe-events-pg-template .category-jobs-admin ol li, .tribe-events-pg-template fieldset.fieldset-cap_declaration ol li, .tribe-events-pg-template .events-promo ol li, .tribe-events-pg-template .category-jobs-admin ol li, .edp-jobs.add-job .entry-content ol li, .edp-jobs.add-job .job_description ol li, .edp-jobs.add-job .tribe-events-content ol li, .edp-jobs.add-job .edp-thesis-abstract ol li, .edp-jobs.add-job .category-jobs-admin ol li, .edp-jobs.add-job fieldset.fieldset-cap_declaration ol li, .edp-jobs.add-job .events-promo ol li, .edp-jobs.add-job .category-jobs-admin ol li {
+    list-style-type: decimal;
+    margin-left: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content ol, .page-template-default:not(.job-listings-page) article.type-page .job_description ol, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content ol, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract ol, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ol, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration ol, .page-template-default:not(.job-listings-page) article.type-page .events-promo ol, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ol, article.job_listing .entry-content ol, article.job_listing .job_description ol, article.job_listing .tribe-events-content ol, article.job_listing .edp-thesis-abstract ol, article.job_listing .category-jobs-admin ol, article.job_listing fieldset.fieldset-cap_declaration ol, article.job_listing .events-promo ol, article.job_listing .category-jobs-admin ol, article.tribe-events-single .entry-content ol, article.tribe-events-single .job_description ol, article.tribe-events-single .tribe-events-content ol, article.tribe-events-single .edp-thesis-abstract ol, article.tribe-events-single .category-jobs-admin ol, article.tribe-events-single fieldset.fieldset-cap_declaration ol, article.tribe-events-single .events-promo ol, article.tribe-events-single .category-jobs-admin ol, body:not(.home) article.type-post .entry-content ol, body:not(.home) article.type-post .job_description ol, body:not(.home) article.type-post .tribe-events-content ol, body:not(.home) article.type-post .edp-thesis-abstract ol, body:not(.home) article.type-post .category-jobs-admin ol, body:not(.home) article.type-post fieldset.fieldset-cap_declaration ol, body:not(.home) article.type-post .events-promo ol, body:not(.home) article.type-post .category-jobs-admin ol, article.type-wpbdp_listing .entry-content ol, article.type-wpbdp_listing .job_description ol, article.type-wpbdp_listing .tribe-events-content ol, article.type-wpbdp_listing .edp-thesis-abstract ol, article.type-wpbdp_listing .category-jobs-admin ol, article.type-wpbdp_listing fieldset.fieldset-cap_declaration ol, article.type-wpbdp_listing .events-promo ol, article.type-wpbdp_listing .category-jobs-admin ol, .tribe-events-pg-template .entry-content ol, .tribe-events-pg-template .job_description ol, .tribe-events-pg-template .tribe-events-content ol, .tribe-events-pg-template .edp-thesis-abstract ol, .tribe-events-pg-template .category-jobs-admin ol, .tribe-events-pg-template fieldset.fieldset-cap_declaration ol, .tribe-events-pg-template .events-promo ol, .tribe-events-pg-template .category-jobs-admin ol, .edp-jobs.add-job .entry-content ol, .edp-jobs.add-job .job_description ol, .edp-jobs.add-job .tribe-events-content ol, .edp-jobs.add-job .edp-thesis-abstract ol, .edp-jobs.add-job .category-jobs-admin ol, .edp-jobs.add-job fieldset.fieldset-cap_declaration ol, .edp-jobs.add-job .events-promo ol, .edp-jobs.add-job .category-jobs-admin ol {
+    margin-left: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content p, .page-template-default:not(.job-listings-page) article.type-page .entry-content ul, .page-template-default:not(.job-listings-page) article.type-page .entry-content ol, .page-template-default:not(.job-listings-page) article.type-page .job_description p, .page-template-default:not(.job-listings-page) article.type-page .job_description ul, .page-template-default:not(.job-listings-page) article.type-page .job_description ol, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content p, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content ul, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content ol, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract p, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract ul, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract ol, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin p, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ul, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ol, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration p, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration ul, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration ol, .page-template-default:not(.job-listings-page) article.type-page .events-promo p, .page-template-default:not(.job-listings-page) article.type-page .events-promo ul, .page-template-default:not(.job-listings-page) article.type-page .events-promo ol, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin p, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ul, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin ol, article.job_listing .entry-content p, article.job_listing .entry-content ul, article.job_listing .entry-content ol, article.job_listing .job_description p, article.job_listing .job_description ul, article.job_listing .job_description ol, article.job_listing .tribe-events-content p, article.job_listing .tribe-events-content ul, article.job_listing .tribe-events-content ol, article.job_listing .edp-thesis-abstract p, article.job_listing .edp-thesis-abstract ul, article.job_listing .edp-thesis-abstract ol, article.job_listing .category-jobs-admin p, article.job_listing .category-jobs-admin ul, article.job_listing .category-jobs-admin ol, article.job_listing fieldset.fieldset-cap_declaration p, article.job_listing fieldset.fieldset-cap_declaration ul, article.job_listing fieldset.fieldset-cap_declaration ol, article.job_listing .events-promo p, article.job_listing .events-promo ul, article.job_listing .events-promo ol, article.job_listing .category-jobs-admin p, article.job_listing .category-jobs-admin ul, article.job_listing .category-jobs-admin ol, article.tribe-events-single .entry-content p, article.tribe-events-single .entry-content ul, article.tribe-events-single .entry-content ol, article.tribe-events-single .job_description p, article.tribe-events-single .job_description ul, article.tribe-events-single .job_description ol, article.tribe-events-single .tribe-events-content p, article.tribe-events-single .tribe-events-content ul, article.tribe-events-single .tribe-events-content ol, article.tribe-events-single .edp-thesis-abstract p, article.tribe-events-single .edp-thesis-abstract ul, article.tribe-events-single .edp-thesis-abstract ol, article.tribe-events-single .category-jobs-admin p, article.tribe-events-single .category-jobs-admin ul, article.tribe-events-single .category-jobs-admin ol, article.tribe-events-single fieldset.fieldset-cap_declaration p, article.tribe-events-single fieldset.fieldset-cap_declaration ul, article.tribe-events-single fieldset.fieldset-cap_declaration ol, article.tribe-events-single .events-promo p, article.tribe-events-single .events-promo ul, article.tribe-events-single .events-promo ol, article.tribe-events-single .category-jobs-admin p, article.tribe-events-single .category-jobs-admin ul, article.tribe-events-single .category-jobs-admin ol, body:not(.home) article.type-post .entry-content p, body:not(.home) article.type-post .entry-content ul, body:not(.home) article.type-post .entry-content ol, body:not(.home) article.type-post .job_description p, body:not(.home) article.type-post .job_description ul, body:not(.home) article.type-post .job_description ol, body:not(.home) article.type-post .tribe-events-content p, body:not(.home) article.type-post .tribe-events-content ul, body:not(.home) article.type-post .tribe-events-content ol, body:not(.home) article.type-post .edp-thesis-abstract p, body:not(.home) article.type-post .edp-thesis-abstract ul, body:not(.home) article.type-post .edp-thesis-abstract ol, body:not(.home) article.type-post .category-jobs-admin p, body:not(.home) article.type-post .category-jobs-admin ul, body:not(.home) article.type-post .category-jobs-admin ol, body:not(.home) article.type-post fieldset.fieldset-cap_declaration p, body:not(.home) article.type-post fieldset.fieldset-cap_declaration ul, body:not(.home) article.type-post fieldset.fieldset-cap_declaration ol, body:not(.home) article.type-post .events-promo p, body:not(.home) article.type-post .events-promo ul, body:not(.home) article.type-post .events-promo ol, body:not(.home) article.type-post .category-jobs-admin p, body:not(.home) article.type-post .category-jobs-admin ul, body:not(.home) article.type-post .category-jobs-admin ol, article.type-wpbdp_listing .entry-content p, article.type-wpbdp_listing .entry-content ul, article.type-wpbdp_listing .entry-content ol, article.type-wpbdp_listing .job_description p, article.type-wpbdp_listing .job_description ul, article.type-wpbdp_listing .job_description ol, article.type-wpbdp_listing .tribe-events-content p, article.type-wpbdp_listing .tribe-events-content ul, article.type-wpbdp_listing .tribe-events-content ol, article.type-wpbdp_listing .edp-thesis-abstract p, article.type-wpbdp_listing .edp-thesis-abstract ul, article.type-wpbdp_listing .edp-thesis-abstract ol, article.type-wpbdp_listing .category-jobs-admin p, article.type-wpbdp_listing .category-jobs-admin ul, article.type-wpbdp_listing .category-jobs-admin ol, article.type-wpbdp_listing fieldset.fieldset-cap_declaration p, article.type-wpbdp_listing fieldset.fieldset-cap_declaration ul, article.type-wpbdp_listing fieldset.fieldset-cap_declaration ol, article.type-wpbdp_listing .events-promo p, article.type-wpbdp_listing .events-promo ul, article.type-wpbdp_listing .events-promo ol, article.type-wpbdp_listing .category-jobs-admin p, article.type-wpbdp_listing .category-jobs-admin ul, article.type-wpbdp_listing .category-jobs-admin ol, .tribe-events-pg-template .entry-content p, .tribe-events-pg-template .entry-content ul, .tribe-events-pg-template .entry-content ol, .tribe-events-pg-template .job_description p, .tribe-events-pg-template .job_description ul, .tribe-events-pg-template .job_description ol, .tribe-events-pg-template .tribe-events-content p, .tribe-events-pg-template .tribe-events-content ul, .tribe-events-pg-template .tribe-events-content ol, .tribe-events-pg-template .edp-thesis-abstract p, .tribe-events-pg-template .edp-thesis-abstract ul, .tribe-events-pg-template .edp-thesis-abstract ol, .tribe-events-pg-template .category-jobs-admin p, .tribe-events-pg-template .category-jobs-admin ul, .tribe-events-pg-template .category-jobs-admin ol, .tribe-events-pg-template fieldset.fieldset-cap_declaration p, .tribe-events-pg-template fieldset.fieldset-cap_declaration ul, .tribe-events-pg-template fieldset.fieldset-cap_declaration ol, .tribe-events-pg-template .events-promo p, .tribe-events-pg-template .events-promo ul, .tribe-events-pg-template .events-promo ol, .tribe-events-pg-template .category-jobs-admin p, .tribe-events-pg-template .category-jobs-admin ul, .tribe-events-pg-template .category-jobs-admin ol, .edp-jobs.add-job .entry-content p, .edp-jobs.add-job .entry-content ul, .edp-jobs.add-job .entry-content ol, .edp-jobs.add-job .job_description p, .edp-jobs.add-job .job_description ul, .edp-jobs.add-job .job_description ol, .edp-jobs.add-job .tribe-events-content p, .edp-jobs.add-job .tribe-events-content ul, .edp-jobs.add-job .tribe-events-content ol, .edp-jobs.add-job .edp-thesis-abstract p, .edp-jobs.add-job .edp-thesis-abstract ul, .edp-jobs.add-job .edp-thesis-abstract ol, .edp-jobs.add-job .category-jobs-admin p, .edp-jobs.add-job .category-jobs-admin ul, .edp-jobs.add-job .category-jobs-admin ol, .edp-jobs.add-job fieldset.fieldset-cap_declaration p, .edp-jobs.add-job fieldset.fieldset-cap_declaration ul, .edp-jobs.add-job fieldset.fieldset-cap_declaration ol, .edp-jobs.add-job .events-promo p, .edp-jobs.add-job .events-promo ul, .edp-jobs.add-job .events-promo ol, .edp-jobs.add-job .category-jobs-admin p, .edp-jobs.add-job .category-jobs-admin ul, .edp-jobs.add-job .category-jobs-admin ol {
+    margin-bottom: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content h2, .page-template-default:not(.job-listings-page) article.type-page .entry-content h3, .page-template-default:not(.job-listings-page) article.type-page .job_description h2, .page-template-default:not(.job-listings-page) article.type-page .job_description h3, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content h2, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content h3, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract h2, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract h3, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin h2, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin h3, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration h2, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration h3, .page-template-default:not(.job-listings-page) article.type-page .events-promo h2, .page-template-default:not(.job-listings-page) article.type-page .events-promo h3, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin h2, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin h3, article.job_listing .entry-content h2, article.job_listing .entry-content h3, article.job_listing .job_description h2, article.job_listing .job_description h3, article.job_listing .tribe-events-content h2, article.job_listing .tribe-events-content h3, article.job_listing .edp-thesis-abstract h2, article.job_listing .edp-thesis-abstract h3, article.job_listing .category-jobs-admin h2, article.job_listing .category-jobs-admin h3, article.job_listing fieldset.fieldset-cap_declaration h2, article.job_listing fieldset.fieldset-cap_declaration h3, article.job_listing .events-promo h2, article.job_listing .events-promo h3, article.job_listing .category-jobs-admin h2, article.job_listing .category-jobs-admin h3, article.tribe-events-single .entry-content h2, article.tribe-events-single .entry-content h3, article.tribe-events-single .job_description h2, article.tribe-events-single .job_description h3, article.tribe-events-single .tribe-events-content h2, article.tribe-events-single .tribe-events-content h3, article.tribe-events-single .edp-thesis-abstract h2, article.tribe-events-single .edp-thesis-abstract h3, article.tribe-events-single .category-jobs-admin h2, article.tribe-events-single .category-jobs-admin h3, article.tribe-events-single fieldset.fieldset-cap_declaration h2, article.tribe-events-single fieldset.fieldset-cap_declaration h3, article.tribe-events-single .events-promo h2, article.tribe-events-single .events-promo h3, article.tribe-events-single .category-jobs-admin h2, article.tribe-events-single .category-jobs-admin h3, body:not(.home) article.type-post .entry-content h2, body:not(.home) article.type-post .entry-content h3, body:not(.home) article.type-post .job_description h2, body:not(.home) article.type-post .job_description h3, body:not(.home) article.type-post .tribe-events-content h2, body:not(.home) article.type-post .tribe-events-content h3, body:not(.home) article.type-post .edp-thesis-abstract h2, body:not(.home) article.type-post .edp-thesis-abstract h3, body:not(.home) article.type-post .category-jobs-admin h2, body:not(.home) article.type-post .category-jobs-admin h3, body:not(.home) article.type-post fieldset.fieldset-cap_declaration h2, body:not(.home) article.type-post fieldset.fieldset-cap_declaration h3, body:not(.home) article.type-post .events-promo h2, body:not(.home) article.type-post .events-promo h3, body:not(.home) article.type-post .category-jobs-admin h2, body:not(.home) article.type-post .category-jobs-admin h3, article.type-wpbdp_listing .entry-content h2, article.type-wpbdp_listing .entry-content h3, article.type-wpbdp_listing .job_description h2, article.type-wpbdp_listing .job_description h3, article.type-wpbdp_listing .tribe-events-content h2, article.type-wpbdp_listing .tribe-events-content h3, article.type-wpbdp_listing .edp-thesis-abstract h2, article.type-wpbdp_listing .edp-thesis-abstract h3, article.type-wpbdp_listing .category-jobs-admin h2, article.type-wpbdp_listing .category-jobs-admin h3, article.type-wpbdp_listing fieldset.fieldset-cap_declaration h2, article.type-wpbdp_listing fieldset.fieldset-cap_declaration h3, article.type-wpbdp_listing .events-promo h2, article.type-wpbdp_listing .events-promo h3, article.type-wpbdp_listing .category-jobs-admin h2, article.type-wpbdp_listing .category-jobs-admin h3, .tribe-events-pg-template .entry-content h2, .tribe-events-pg-template .entry-content h3, .tribe-events-pg-template .job_description h2, .tribe-events-pg-template .job_description h3, .tribe-events-pg-template .tribe-events-content h2, .tribe-events-pg-template .tribe-events-content h3, .tribe-events-pg-template .edp-thesis-abstract h2, .tribe-events-pg-template .edp-thesis-abstract h3, .tribe-events-pg-template .category-jobs-admin h2, .tribe-events-pg-template .category-jobs-admin h3, .tribe-events-pg-template fieldset.fieldset-cap_declaration h2, .tribe-events-pg-template fieldset.fieldset-cap_declaration h3, .tribe-events-pg-template .events-promo h2, .tribe-events-pg-template .events-promo h3, .tribe-events-pg-template .category-jobs-admin h2, .tribe-events-pg-template .category-jobs-admin h3, .edp-jobs.add-job .entry-content h2, .edp-jobs.add-job .entry-content h3, .edp-jobs.add-job .job_description h2, .edp-jobs.add-job .job_description h3, .edp-jobs.add-job .tribe-events-content h2, .edp-jobs.add-job .tribe-events-content h3, .edp-jobs.add-job .edp-thesis-abstract h2, .edp-jobs.add-job .edp-thesis-abstract h3, .edp-jobs.add-job .category-jobs-admin h2, .edp-jobs.add-job .category-jobs-admin h3, .edp-jobs.add-job fieldset.fieldset-cap_declaration h2, .edp-jobs.add-job fieldset.fieldset-cap_declaration h3, .edp-jobs.add-job .events-promo h2, .edp-jobs.add-job .events-promo h3, .edp-jobs.add-job .category-jobs-admin h2, .edp-jobs.add-job .category-jobs-admin h3 {
+    margin-bottom: var(--sp-small);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content blockquote, .page-template-default:not(.job-listings-page) article.type-page .job_description blockquote, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content blockquote, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract blockquote, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin blockquote, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration blockquote, .page-template-default:not(.job-listings-page) article.type-page .events-promo blockquote, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin blockquote, article.job_listing .entry-content blockquote, article.job_listing .job_description blockquote, article.job_listing .tribe-events-content blockquote, article.job_listing .edp-thesis-abstract blockquote, article.job_listing .category-jobs-admin blockquote, article.job_listing fieldset.fieldset-cap_declaration blockquote, article.job_listing .events-promo blockquote, article.job_listing .category-jobs-admin blockquote, article.tribe-events-single .entry-content blockquote, article.tribe-events-single .job_description blockquote, article.tribe-events-single .tribe-events-content blockquote, article.tribe-events-single .edp-thesis-abstract blockquote, article.tribe-events-single .category-jobs-admin blockquote, article.tribe-events-single fieldset.fieldset-cap_declaration blockquote, article.tribe-events-single .events-promo blockquote, article.tribe-events-single .category-jobs-admin blockquote, body:not(.home) article.type-post .entry-content blockquote, body:not(.home) article.type-post .job_description blockquote, body:not(.home) article.type-post .tribe-events-content blockquote, body:not(.home) article.type-post .edp-thesis-abstract blockquote, body:not(.home) article.type-post .category-jobs-admin blockquote, body:not(.home) article.type-post fieldset.fieldset-cap_declaration blockquote, body:not(.home) article.type-post .events-promo blockquote, body:not(.home) article.type-post .category-jobs-admin blockquote, article.type-wpbdp_listing .entry-content blockquote, article.type-wpbdp_listing .job_description blockquote, article.type-wpbdp_listing .tribe-events-content blockquote, article.type-wpbdp_listing .edp-thesis-abstract blockquote, article.type-wpbdp_listing .category-jobs-admin blockquote, article.type-wpbdp_listing fieldset.fieldset-cap_declaration blockquote, article.type-wpbdp_listing .events-promo blockquote, article.type-wpbdp_listing .category-jobs-admin blockquote, .tribe-events-pg-template .entry-content blockquote, .tribe-events-pg-template .job_description blockquote, .tribe-events-pg-template .tribe-events-content blockquote, .tribe-events-pg-template .edp-thesis-abstract blockquote, .tribe-events-pg-template .category-jobs-admin blockquote, .tribe-events-pg-template fieldset.fieldset-cap_declaration blockquote, .tribe-events-pg-template .events-promo blockquote, .tribe-events-pg-template .category-jobs-admin blockquote, .edp-jobs.add-job .entry-content blockquote, .edp-jobs.add-job .job_description blockquote, .edp-jobs.add-job .tribe-events-content blockquote, .edp-jobs.add-job .edp-thesis-abstract blockquote, .edp-jobs.add-job .category-jobs-admin blockquote, .edp-jobs.add-job fieldset.fieldset-cap_declaration blockquote, .edp-jobs.add-job .events-promo blockquote, .edp-jobs.add-job .category-jobs-admin blockquote {
+    border-left: 6px solid var(--cl-primary);
+    padding-left: var(--sp-medium);
+    margin-bottom: var(--sp-medium);
+    margin-left: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content img.img-half-max.alignleft, .page-template-default:not(.job-listings-page) article.type-page .job_description img.img-half-max.alignleft, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content img.img-half-max.alignleft, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract img.img-half-max.alignleft, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin img.img-half-max.alignleft, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration img.img-half-max.alignleft, .page-template-default:not(.job-listings-page) article.type-page .events-promo img.img-half-max.alignleft, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin img.img-half-max.alignleft, article.job_listing .entry-content img.img-half-max.alignleft, article.job_listing .job_description img.img-half-max.alignleft, article.job_listing .tribe-events-content img.img-half-max.alignleft, article.job_listing .edp-thesis-abstract img.img-half-max.alignleft, article.job_listing .category-jobs-admin img.img-half-max.alignleft, article.job_listing fieldset.fieldset-cap_declaration img.img-half-max.alignleft, article.job_listing .events-promo img.img-half-max.alignleft, article.job_listing .category-jobs-admin img.img-half-max.alignleft, article.tribe-events-single .entry-content img.img-half-max.alignleft, article.tribe-events-single .job_description img.img-half-max.alignleft, article.tribe-events-single .tribe-events-content img.img-half-max.alignleft, article.tribe-events-single .edp-thesis-abstract img.img-half-max.alignleft, article.tribe-events-single .category-jobs-admin img.img-half-max.alignleft, article.tribe-events-single fieldset.fieldset-cap_declaration img.img-half-max.alignleft, article.tribe-events-single .events-promo img.img-half-max.alignleft, article.tribe-events-single .category-jobs-admin img.img-half-max.alignleft, body:not(.home) article.type-post .entry-content img.img-half-max.alignleft, body:not(.home) article.type-post .job_description img.img-half-max.alignleft, body:not(.home) article.type-post .tribe-events-content img.img-half-max.alignleft, body:not(.home) article.type-post .edp-thesis-abstract img.img-half-max.alignleft, body:not(.home) article.type-post .category-jobs-admin img.img-half-max.alignleft, body:not(.home) article.type-post fieldset.fieldset-cap_declaration img.img-half-max.alignleft, body:not(.home) article.type-post .events-promo img.img-half-max.alignleft, body:not(.home) article.type-post .category-jobs-admin img.img-half-max.alignleft, article.type-wpbdp_listing .entry-content img.img-half-max.alignleft, article.type-wpbdp_listing .job_description img.img-half-max.alignleft, article.type-wpbdp_listing .tribe-events-content img.img-half-max.alignleft, article.type-wpbdp_listing .edp-thesis-abstract img.img-half-max.alignleft, article.type-wpbdp_listing .category-jobs-admin img.img-half-max.alignleft, article.type-wpbdp_listing fieldset.fieldset-cap_declaration img.img-half-max.alignleft, article.type-wpbdp_listing .events-promo img.img-half-max.alignleft, article.type-wpbdp_listing .category-jobs-admin img.img-half-max.alignleft, .tribe-events-pg-template .entry-content img.img-half-max.alignleft, .tribe-events-pg-template .job_description img.img-half-max.alignleft, .tribe-events-pg-template .tribe-events-content img.img-half-max.alignleft, .tribe-events-pg-template .edp-thesis-abstract img.img-half-max.alignleft, .tribe-events-pg-template .category-jobs-admin img.img-half-max.alignleft, .tribe-events-pg-template fieldset.fieldset-cap_declaration img.img-half-max.alignleft, .tribe-events-pg-template .events-promo img.img-half-max.alignleft, .tribe-events-pg-template .category-jobs-admin img.img-half-max.alignleft, .edp-jobs.add-job .entry-content img.img-half-max.alignleft, .edp-jobs.add-job .job_description img.img-half-max.alignleft, .edp-jobs.add-job .tribe-events-content img.img-half-max.alignleft, .edp-jobs.add-job .edp-thesis-abstract img.img-half-max.alignleft, .edp-jobs.add-job .category-jobs-admin img.img-half-max.alignleft, .edp-jobs.add-job fieldset.fieldset-cap_declaration img.img-half-max.alignleft, .edp-jobs.add-job .events-promo img.img-half-max.alignleft, .edp-jobs.add-job .category-jobs-admin img.img-half-max.alignleft {
+    width: 50%;
+    max-width: 300px;
+    float: left;
+    height: auto;
+    margin-right: var(--sp-medium);
+    margin-bottom: var(--sp-medium);
+    border-radius: var(--rd-large);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .entry-content img, .page-template-default:not(.job-listings-page) article.type-page .job_description img, .page-template-default:not(.job-listings-page) article.type-page .tribe-events-content img, .page-template-default:not(.job-listings-page) article.type-page .edp-thesis-abstract img, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin img, .page-template-default:not(.job-listings-page) article.type-page fieldset.fieldset-cap_declaration img, .page-template-default:not(.job-listings-page) article.type-page .events-promo img, .page-template-default:not(.job-listings-page) article.type-page .category-jobs-admin img, article.job_listing .entry-content img, article.job_listing .job_description img, article.job_listing .tribe-events-content img, article.job_listing .edp-thesis-abstract img, article.job_listing .category-jobs-admin img, article.job_listing fieldset.fieldset-cap_declaration img, article.job_listing .events-promo img, article.job_listing .category-jobs-admin img, article.tribe-events-single .entry-content img, article.tribe-events-single .job_description img, article.tribe-events-single .tribe-events-content img, article.tribe-events-single .edp-thesis-abstract img, article.tribe-events-single .category-jobs-admin img, article.tribe-events-single fieldset.fieldset-cap_declaration img, article.tribe-events-single .events-promo img, article.tribe-events-single .category-jobs-admin img, body:not(.home) article.type-post .entry-content img, body:not(.home) article.type-post .job_description img, body:not(.home) article.type-post .tribe-events-content img, body:not(.home) article.type-post .edp-thesis-abstract img, body:not(.home) article.type-post .category-jobs-admin img, body:not(.home) article.type-post fieldset.fieldset-cap_declaration img, body:not(.home) article.type-post .events-promo img, body:not(.home) article.type-post .category-jobs-admin img, article.type-wpbdp_listing .entry-content img, article.type-wpbdp_listing .job_description img, article.type-wpbdp_listing .tribe-events-content img, article.type-wpbdp_listing .edp-thesis-abstract img, article.type-wpbdp_listing .category-jobs-admin img, article.type-wpbdp_listing fieldset.fieldset-cap_declaration img, article.type-wpbdp_listing .events-promo img, article.type-wpbdp_listing .category-jobs-admin img, .tribe-events-pg-template .entry-content img, .tribe-events-pg-template .job_description img, .tribe-events-pg-template .tribe-events-content img, .tribe-events-pg-template .edp-thesis-abstract img, .tribe-events-pg-template .category-jobs-admin img, .tribe-events-pg-template fieldset.fieldset-cap_declaration img, .tribe-events-pg-template .events-promo img, .tribe-events-pg-template .category-jobs-admin img, .edp-jobs.add-job .entry-content img, .edp-jobs.add-job .job_description img, .edp-jobs.add-job .tribe-events-content img, .edp-jobs.add-job .edp-thesis-abstract img, .edp-jobs.add-job .category-jobs-admin img, .edp-jobs.add-job fieldset.fieldset-cap_declaration img, .edp-jobs.add-job .events-promo img, .edp-jobs.add-job .category-jobs-admin img {
+    height: auto;
+    margin: 0;
+    max-width: 100%;
+}
+
+.page-template-default:not(.job-listings-page) article.type-page h2.author-title, article.job_listing h2.author-title, article.tribe-events-single h2.author-title, body:not(.home) article.type-post h2.author-title, article.type-wpbdp_listing h2.author-title, .tribe-events-pg-template h2.author-title, .edp-jobs.add-job h2.author-title {
+    margin-bottom: var(--sp-medium);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page .crp_related h2, article.job_listing .crp_related h2, article.tribe-events-single .crp_related h2, body:not(.home) article.type-post .crp_related h2, article.type-wpbdp_listing .crp_related h2, .tribe-events-pg-template .crp_related h2, .edp-jobs.add-job .crp_related h2 {
+    margin-bottom: var(--sp-large);
+}
+
+.page-template-default:not(.job-listings-page) article.type-page, article.job_listing, article.tribe-events-single, body:not(.home) article.type-post, article.type-wpbdp_listing, .tribe-events-pg-template, .edp-jobs.add-job {
+    margin-bottom: var(--sp-xxlarge);
+}
+
+.page-template-default.page-id-5008:lang(ur), .page-template-default.page-id-5008:lang(ar), .page-template-default.page-id-5006:lang(ur), .page-template-default.page-id-5006:lang(ar), .page-template-default.page-id-5010:lang(ur), .page-template-default.page-id-5010:lang(ar), .page-template-default.page-id-13601:lang(ur), .page-template-default.page-id-13601:lang(ar), .page-template-default.page-id-13702:lang(ur), .page-template-default.page-id-13702:lang(ar), .page-template-default.page-id-13632:lang(ur), .page-template-default.page-id-13632:lang(ar) {
+    font-family: arial, sans-serif;
+}
+
+.page-template-default.page-id-5008:lang(en), .page-template-default.page-id-5006:lang(en), .page-template-default.page-id-5010:lang(en), .page-template-default.page-id-13601:lang(en), .page-template-default.page-id-13702:lang(en), .page-template-default.page-id-13632:lang(en) {
+    font-family: var(--ff);
+}
+
+article.type-post .entry-content .content-body>p:first-of-type {
+    font-size: var(--fs-title-small);
+    line-height: var(--lh-title-small);
+    margin-bottom: var(--sp-medium);
+}
+
+.post-type-archive-tribe_events header:not(role="banner") {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    align-content: flex-start;
+}
+
+.job-listings-page article header, .business-directory article header, .archive main header.header, .tribe-events header.tribe-events-header, .add-job header.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    align-content: flex-start;
+}
+
+.single-post article header h1, .page-template-default:not(.edp-jobs) header h1 {
+    font-size: var(--fs-title-xlarge);
+    line-height: var(--lh-title-xlarge);
+}
+
+.single-post article header .entry-title, .page-template-default:not(.edp-jobs) header .entry-title {
+    margin-bottom: var(--sp-xxlarge);
+}
+
+.single-post article.page-id-5008 h1.entry-title, .single-post article.page-id-5006 h1.entry-title, .single-post article.page-id-5010 h1.entry-title, .single-post article.page-id-13601 h1.entry-title, .single-post article.page-id-13702 h1.entry-title, .single-post article.page-id-13632 h1.entry-title, .page-template-default:not(.edp-jobs).page-id-5008 h1.entry-title, .page-template-default:not(.edp-jobs).page-id-5006 h1.entry-title, .page-template-default:not(.edp-jobs).page-id-5010 h1.entry-title, .page-template-default:not(.edp-jobs).page-id-13601 h1.entry-title, .page-template-default:not(.edp-jobs).page-id-13702 h1.entry-title, .page-template-default:not(.edp-jobs).page-id-13632 h1.entry-title {
+    margin-bottom: var(--sp-medium);
+}
+
+.single-post article.page-id-5008 .entry-content .translation-options h2, .single-post article.page-id-5006 .entry-content .translation-options h2, .single-post article.page-id-5010 .entry-content .translation-options h2, .single-post article.page-id-13601 .entry-content .translation-options h2, .single-post article.page-id-13702 .entry-content .translation-options h2, .single-post article.page-id-13632 .entry-content .translation-options h2, .page-template-default:not(.edp-jobs).page-id-5008 .entry-content .translation-options h2, .page-template-default:not(.edp-jobs).page-id-5006 .entry-content .translation-options h2, .page-template-default:not(.edp-jobs).page-id-5010 .entry-content .translation-options h2, .page-template-default:not(.edp-jobs).page-id-13601 .entry-content .translation-options h2, .page-template-default:not(.edp-jobs).page-id-13702 .entry-content .translation-options h2, .page-template-default:not(.edp-jobs).page-id-13632 .entry-content .translation-options h2 {
+    margin-bottom: var(--sp-large);
+}
+
+.single-post article.page-id-5008 .entry-content .translation-options p, .single-post article.page-id-5006 .entry-content .translation-options p, .single-post article.page-id-5010 .entry-content .translation-options p, .single-post article.page-id-13601 .entry-content .translation-options p, .single-post article.page-id-13702 .entry-content .translation-options p, .single-post article.page-id-13632 .entry-content .translation-options p, .page-template-default:not(.edp-jobs).page-id-5008 .entry-content .translation-options p, .page-template-default:not(.edp-jobs).page-id-5006 .entry-content .translation-options p, .page-template-default:not(.edp-jobs).page-id-5010 .entry-content .translation-options p, .page-template-default:not(.edp-jobs).page-id-13601 .entry-content .translation-options p, .page-template-default:not(.edp-jobs).page-id-13702 .entry-content .translation-options p, .page-template-default:not(.edp-jobs).page-id-13632 .entry-content .translation-options p {
+    outline: solid 1px var(--cl-dark);
+    padding: var(--sp-small) var(--sp-medium);
+}
+
+.wp-singular.page-template.page-template-template-fullwidth-jobs h1 {
+    font-size: var(--fs-title-xlarge);
+    line-height: var(--lh-title-xlarge);
+}
+
+.page-promo a .promo-subtitle {
+    margin-left: var(--sp-medium);
+    font-size: var(--fs-body);
+    font-weight: var(--fw-light);
+    line-height: var(--lh-body);
+}
+
+.page-promo a.edp-blog-promo:link, .page-promo a.edp-blog-promo:visited {
+    color: var(--cl-blog-primary);
+}
+
+.page-promo a.edp-blog-promo:hover, .page-promo a.edp-blog-promo:active {
+    background-color: var(--cl-blog-primary);
+    color: var(--cl-light);
+}
+
+.page-promo a.edp-blog-promo {
+    color: var(--cl-blog-primary);
+    border-color: var(--cl-blog-primary);
+}
+
+.page-promo a.edp-jobs-promo .promo-text {
+    display: flex;
+    align-items: flex-start;
+}
+
+.page-promo a.edp-jobs-promo {
+    padding: var(--sp-medium);
+}
+
+.page-promo a i {
+    margin-left: var(--sp-medium);
+}
+
+.page-promo a:link, .page-promo a:visited {
+    color: var(--cl-light);
+}
+
+.page-promo a.edp-thesis-promo:link, .page-promo a.edp-thesis-promo:visited {
+    background-color: var(--cl-light-15);
+}
+
+.page-promo a.edp-events-promo:link, .page-promo a.edp-events-promo:visited {
+    background-color: var(--cl-dark-50);
+}
+
+.page-promo a:hover, .page-promo a.edp-events-promo:hover, .page-promo a:active, .page-promo a.edp-events-promo:active, .page-promo a.edp-thesis-promo:hover, .page-promo a.edp-thesis-promo:active {
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+    box-shadow: none;
+}
+
+.page-promo a {
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--cl-light);
+    padding: var(--sp-small) var(--sp-medium);
+    font-size: var(--fs-title-small);
+    font-weight: var(--fw-semibold);
+}
+
+.home .homepage-jobs .article-item:hover a, .home .homepage-jobs .article-item:active a {
+    color: var(--cl-dark-75) !important;
+}
+
+.home .homepage-jobs .article-item .edp-jobs-promo--home .home-article-image .promo-text .promo-title {
+    margin-bottom: var(--sp-small);
+    color: var(--cl-orange);
+}
+
+.home .homepage-jobs .article-item .edp-jobs-promo--home .home-article-image .promo-text .promo-subtitle {
+    margin-left: 0;
+    text-align: left;
+}
+
+.home .homepage-jobs .article-item .edp-jobs-promo--home .home-article-image .promo-text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.home .homepage-jobs .article-item .edp-jobs-promo--home .home-article-image {
+    padding: var(--sp-medium);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.home .homepage-jobs .article-item .edp-jobs-promo--home i {
+    color: var(--cl-orange);
+}
+
+.home .homepage-jobs .article-item .edp-jobs-promo--home h3 {
+    display: none;
+}
+
+.home .homepage-jobs .article-item .edp-jobs-promo--home {
+    flex-direction: column;
+    padding: 0;
+}
+
+body:not(.home) h1, body:not(.home) h2.my-events, .tribe_community_edit h1, .tribe_community_edit h2.my-events, .post-type-archive-tribe_events h1, .post-type-archive-tribe_events h2.my-events {
+    font-weight: var(--fw-semibold);
+    margin: var(--sp-xxlarge) 0 var(--sp-xxlarge) 0;
+    font-size: var(--fs-title-xlarge);
+}
+
+body:not(.home) .title-tag h1, .tribe_community_edit .title-tag h1, .post-type-archive-tribe_events .title-tag h1 {
+    margin-bottom: var(--sp-small);
+}
+
+body:not(.home) .title-tag h2 .fa-tags, body:not(.home) .title-tag h2 .fa-user-circle, .tribe_community_edit .title-tag h2 .fa-tags, .tribe_community_edit .title-tag h2 .fa-user-circle, .post-type-archive-tribe_events .title-tag h2 .fa-tags, .post-type-archive-tribe_events .title-tag h2 .fa-user-circle {
+    color: var(--cl-medpurple);
+}
+
+body:not(.home) .title-tag h2 .tag-block:link .fa-times, body:not(.home) .title-tag h2 .tag-block:visited .fa-times, .tribe_community_edit .title-tag h2 .tag-block:link .fa-times, .tribe_community_edit .title-tag h2 .tag-block:visited .fa-times, .post-type-archive-tribe_events .title-tag h2 .tag-block:link .fa-times, .post-type-archive-tribe_events .title-tag h2 .tag-block:visited .fa-times {
+    color: var(--cl-dark-50);
+}
+
+body:not(.home) .title-tag h2 .tag-block:link, body:not(.home) .title-tag h2 .tag-block:visited, .tribe_community_edit .title-tag h2 .tag-block:link, .tribe_community_edit .title-tag h2 .tag-block:visited, .post-type-archive-tribe_events .title-tag h2 .tag-block:link, .post-type-archive-tribe_events .title-tag h2 .tag-block:visited {
+    border: 2px solid var(--cl-light);
+}
+
+body:not(.home) .title-tag h2 .tag-block:hover .fa-times, body:not(.home) .title-tag h2 .tag-block:active .fa-times, .tribe_community_edit .title-tag h2 .tag-block:hover .fa-times, .tribe_community_edit .title-tag h2 .tag-block:active .fa-times, .post-type-archive-tribe_events .title-tag h2 .tag-block:hover .fa-times, .post-type-archive-tribe_events .title-tag h2 .tag-block:active .fa-times {
+    color: var(--cl-medpurple);
+}
+
+body:not(.home) .title-tag h2 .tag-block:hover, body:not(.home) .title-tag h2 .tag-block:active, .tribe_community_edit .title-tag h2 .tag-block:hover, .tribe_community_edit .title-tag h2 .tag-block:active, .post-type-archive-tribe_events .title-tag h2 .tag-block:hover, .post-type-archive-tribe_events .title-tag h2 .tag-block:active {
+    border: 2px solid var(--cl-medpurple);
+}
+
+body:not(.home) .title-tag h2 .tag-block, .tribe_community_edit .title-tag h2 .tag-block, .post-type-archive-tribe_events .title-tag h2 .tag-block {
+    background-color: var(--cl-lightpurple-hover);
+    padding: var(--sp-xxsmall) var(--sp-small) var(--sp-xxsmall) var(--sp-small);
+    display: flex;
+    gap: var(--sp-small);
+    align-items: center;
+    color: var(--cl-dark);
+    border-radius: 4px;
+}
+
+body:not(.home) .title-tag h2, .tribe_community_edit .title-tag h2, .post-type-archive-tribe_events .title-tag h2 {
+    margin-bottom: calc(var(--sp-xxlarge) - var(--sp-small) - 42px);
+    padding-left: var(--sp-xsmall);
+    display: flex;
+    gap: var(--sp-small);
+    align-items: center;
+}
+
+body:not(.home) .wpbdp-listing-single .name-inst-year, .tribe_community_edit .wpbdp-listing-single .name-inst-year, .post-type-archive-tribe_events .wpbdp-listing-single .name-inst-year {
+    margin-top: var(--sp-xxlarge);
+}
+
+body:not(.home) .wpbdp-listing-single h1, .tribe_community_edit .wpbdp-listing-single h1, .post-type-archive-tribe_events .wpbdp-listing-single h1 {
+    margin-top: var(--sp-large);
+    max-width: 850px;
+    font-weight: var(--fw-light);
+}
+
+.job-listings-page h1, .archive h1, .wpbdp-view-main h1 {
+    text-transform: lowercase;
+}
+
+.edp-jobs h1, .archive h1 {
+    font-size: var(--fs-display-large);
+    line-height: var(--lh-display-large);
+}
+
+.business-directory.wpbdp-view-main h1.entry-title, .tribe_community_edit h2.my-events, .category-jobs-admin h1.entry-title {
+    font-size: var(--fs-display-medium);
+    line-height: var(--lh-display-medium);
+}
+
+.business-directory.single-wpbdp_listing h1 {
+    font-size: var(--fs-title-medium);
+    line-height: var(--lh-title-medium);
+}
+
+.edp-jobs h1, .archive.post-type-archive-tribe_events h1, .business-directory.wpbdp-view-main h1 {
+    color: var(--cl-light);
+}
+
+.archive h1 {
+    color: var(--cl-blog-primary);
+    margin-left: -7px;
+}
+
+.single-post h1, .single-tribe_events h1, .edp-jobs.single-job_listing article.type-job_listing h1 {
+    font-size: var(--fs-title-large);
+    line-height: var(--lh-title-large);
+    color: var(--cl-dark);
+    width: 100%;
+    padding-right: var(--sp-xlarge);
+}
+
+body:not(.wp-admin) h2 {
+    font-size: var(--fs-title-medium);
+    font-weight: var(--fw-semibold);
+    line-height: var(--lh-title-medium);
+}
+
+body:not(.wp-admin) h3, body:not(.wp-admin) fieldset label, body:not(.wp-admin) .events-community-post-title label, body:not(.wp-admin) .events-community-post-content label, body:not(.wp-admin) .tribe-section-content label, body:not(.wp-admin) .tribe-events-community-detail label, body:not(.wp-admin) .tribe_community_edit label {
+    font-size: var(--fs-title-small);
+    font-weight: var(--fw-semibold);
+}
+
+input:is([type="button"], [type="submit"], [type="reset"]):disabled, input[type="file"]:disabled::file-selector-button, button:disabled, select:disabled, optgroup:disabled, option:disabled, select[disabled]>option {
+    color: var(--cl-dark);
+    opacity: var(--op-light);
+}
+
+a.button.edp-button-solid:hover, a.button.edp-button-solid:focus, button.edp-button-solid:hover, button.edp-button-solid:focus, .wp-block-button.is-style-fill a:hover, .wp-block-button.is-style-fill a:focus, .wp-block-button a.has-background:hover, .wp-block-button a.has-background:focus, .tribe-button.tribe-button-primary:hover, .tribe-button.tribe-button-primary:focus, input[type="submit"]:hover, input[type="submit"]:focus, input[type="button"]:hover, input[type="button"]:focus, input[type="file"]::file-selector-button:hover, input[type="file"]::file-selector-button:focus {
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+    box-shadow: none;
+}
+
+a.button.edp-button-solid, button.edp-button-solid, .wp-block-button.is-style-fill a, .wp-block-button a.has-background, .tribe-button.tribe-button-primary, input[type="submit"], input[type="button"], input[type="file"]::file-selector-button {
+    font-size: var(--fs-body);
+    color: var(--cl-light);
+    background-color: var(--cl-dark);
+    border: 1px solid var(--cl-dark);
+    padding: var(--sp-xsmall) var(--sp-small);
+    margin: var(--sp-xsmall) 0;
+    font-weight: var(--fw-medium);
+    line-height: var(--lh-body);
+    cursor: pointer;
+    text-transform: lowercase;
+    font-family: var(--ff);
+}
+
+.wp-block-button a.has-background:hover, .wp-block-button a.has-background:focus {
+    background-color: var(--cl-light) !important;
+    color: var(--cl-dark) !important;
+    box-shadow: none;
+    border: 1px solid var(--cl-dark) !important;
+}
+
+.wp-block-button a.has-background {
+    border: 1px solid var(--cl-light);
+}
+
+button.edp-button-pill:hover, button.edp-button-pill:focus {
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+    box-shadow: none;
+}
+
+button.edp-button-pill {
+    width: fit-content;
+    font-size: var(--fs-body);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    border-radius: 9999px;
+    border: none;
+    padding: var(--sp-xxsmall) var(--sp-small-plus);
+    margin: var(--sp-xsmall) 0;
+    font-weight: var(--fw-medium);
+    line-height: var(--lh-body);
+    cursor: pointer;
+    text-transform: lowercase;
+    font-family: var(--ff);
+    background-color: var(--cl-orange);
+    color: var(--cl-light);
+}
+
+a.button.edp-button-outline:hover, a.button.edp-button-outline:focus, button.edp-button-outline:hover, button.edp-button-outline:focus, .wp-block-button a:hover, .wp-block-button a:focus, input[type="submit"].button.secondary:hover, input[type="submit"].button.secondary:focus, .tribe-button.tribe-button-secondary:hover, .tribe-button.tribe-button-secondary:focus, .tribe-events-community-footer input[type="submit"]:hover, .tribe-events-community-footer input[type="submit"]:focus {
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+    box-shadow: none;
+}
+
+a.button.edp-button-outline, button.edp-button-outline, .wp-block-button a, input[type="submit"].button.secondary, .tribe-button.tribe-button-secondary, .tribe-events-community-footer input[type="submit"] {
+    font-size: var(--fs-body);
+    color: var(--cl-dark);
+    background-color: none;
+    background: none;
+    border: 1px solid var(--cl-dark);
+    padding: var(--sp-xsmall) var(--sp-small);
+    margin: var(--sp-xsmall) 0;
+    font-weight: var(--fw-medium);
+    line-height: var(--lh-body);
+    cursor: pointer;
+    text-transform: lowercase;
+    font-family: var(--ff);
+}
+
+a.button.edp-button-outline.edp-button-outline--reversed:hover, a.button.edp-button-outline.edp-button-outline--reversed:focus, button.edp-button-outline.edp-button-outline--reversed:hover, button.edp-button-outline.edp-button-outline--reversed:focus {
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+}
+
+a.button.edp-button-outline.edp-button-outline--reversed, button.edp-button-outline.edp-button-outline--reversed {
+    color: var(--cl-light);
+    background-color: none;
+    border: 1px solid var(--cl-light);
+}
+
+.tribe-events-pg-template .tribe-events-community-footer input[type="submit"]:hover, .tribe-events-pg-template .tribe-events-community-footer input[type="submit"]:focus {
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+    box-shadow: none;
+}
+
+.tribe-events-pg-template .tribe-events-community-footer input[type="submit"] {
+    color: var(--cl-light);
+    border-color: var(--cl-light);
+}
+
+button.edp-button-ghost.edp-button-ghost--reverse:hover, button.edp-button-ghost.edp-button-ghost--reverse:focus, .button.edp-button-ghost.edp-button-ghost--reverse:hover, .button.edp-button-ghost.edp-button-ghost--reverse:focus, button.tribe-events-c-top-bar__datepicker-button:hover, button.tribe-events-c-top-bar__datepicker-button:focus {
+    opacity: var(--op-strong);
+}
+
+button.edp-button-ghost.edp-button-ghost--reverse, .button.edp-button-ghost.edp-button-ghost--reverse, button.tribe-events-c-top-bar__datepicker-button {
+    font-size: var(--fs-body);
+    color: var(--cl-light);
+    padding: var(--sp-xsmall) var(--sp-small);
+}
+
+button.edp-button-ghost:hover, button.edp-button-ghost:focus, .button.edp-button-ghost:hover, .button.edp-button-ghost:focus, .tribe-button.tribe-button-tertiary:hover, .tribe-button.tribe-button-tertiary:focus {
+    opacity: var(--op-strong);
+}
+
+button.edp-button-ghost, .button.edp-button-ghost, .tribe-button.tribe-button-tertiary {
+    font-size: var(--fs-body);
+    color: var(--cl-dark);
+    padding: var(--sp-xsmall) var(--sp-small);
+}
+
+.tribe-common--breakpoint-medium.tribe-events .tribe-events-c-top-bar__today-button:hover, .tribe-common--breakpoint-medium.tribe-events .tribe-events-c-top-bar__today-button:focus, .wpbdp-main-box .submit-btn:hover, .wpbdp-main-box .submit-btn:focus {
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+}
+
+.tribe-common--breakpoint-medium.tribe-events .tribe-events-c-top-bar__today-button, .wpbdp-main-box .submit-btn {
+    color: var(--cl-light);
+    text-transform: lowercase;
+    font-size: var(--fs-body-small);
+    font-weight: var(--fw-normal);
+    line-height: var(--lh-body-small);
+    border: 1px solid var(--cl-light);
+    padding: var(--sp-xxsmall) var(--sp-xsmall);
+}
+
+a.tribe-common-c-btn-icon:is(:link, :visited), .tribe-events-c-nav__prev:is(:link, :visited), .tribe-events-c-nav__next:is(:link, :visited), .tribe-events-c-nav__today:is(:link, :visited) {
+    color: var(--cl-light);
+}
+
+a.tribe-common-c-btn-icon:is(:hover, :active, :focus), .tribe-events-c-nav__prev:is(:hover, :active, :focus), .tribe-events-c-nav__next:is(:hover, :active, :focus), .tribe-events-c-nav__today:is(:hover, :active, :focus) {
+    opacity: var(--op-strong);
+}
+
+.tribe-events a.tribe-events-c-view-selector__list-item-link:is(:link, :visited) {
+    color: var(--cl-dark);
+}
+
+.tribe-events a.tribe-events-c-view-selector__list-item-link:is(:hover, :active) {
+    color: var(--cl-purple);
+    background: var(--cl-lightpurple-hover);
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-events-community-details, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block, .edpsybold .category-jobs-admin .tribe-events-community-details, .edpsybold .category-jobs-admin .tribe-section-content, .edpsybold .category-jobs-admin .form-block, .edpsybold.tribe_community_edit .tribe-events-community-details, .edpsybold.tribe_community_edit .tribe-section-content, .edpsybold.tribe_community_edit .form-block {
+    background-color: var(--cl-light);
+    padding: var(--sp-small) var(--sp-large) var(--sp-small) var(--sp-large);
+    color: var(--cl-dark);
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-events-community-details, .edpsybold .category-jobs-admin .tribe-events-community-details, .edpsybold.tribe_community_edit .tribe-events-community-details {
+    padding-bottom: var(--sp-medium);
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .job-post-promo, .edpsybold .category-jobs-admin .job-post-promo, .edpsybold.tribe_community_edit .job-post-promo {
+    background-color: var(--cl-light);
+    padding: var(--sp-small) var(--sp-large);
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content .tribe-section-content-label, .edpsybold .category-jobs-admin fieldset label, .edpsybold .category-jobs-admin fieldset .tribe-section-content-label, .edpsybold .category-jobs-admin div.venue label, .edpsybold .category-jobs-admin div.venue .tribe-section-content-label, .edpsybold .category-jobs-admin div.organizer label, .edpsybold .category-jobs-admin div.organizer .tribe-section-content-label, .edpsybold .category-jobs-admin .tribe-section-content-row label, .edpsybold .category-jobs-admin .tribe-section-content-row .tribe-section-content-label, .edpsybold .category-jobs-admin div.events-community-post-title label, .edpsybold .category-jobs-admin div.events-community-post-title .tribe-section-content-label, .edpsybold .category-jobs-admin .events-community-post-content label, .edpsybold .category-jobs-admin .events-community-post-content .tribe-section-content-label, .edpsybold.tribe_community_edit fieldset label, .edpsybold.tribe_community_edit fieldset .tribe-section-content-label, .edpsybold.tribe_community_edit div.venue label, .edpsybold.tribe_community_edit div.venue .tribe-section-content-label, .edpsybold.tribe_community_edit div.organizer label, .edpsybold.tribe_community_edit div.organizer .tribe-section-content-label, .edpsybold.tribe_community_edit .tribe-section-content-row label, .edpsybold.tribe_community_edit .tribe-section-content-row .tribe-section-content-label, .edpsybold.tribe_community_edit div.events-community-post-title label, .edpsybold.tribe_community_edit div.events-community-post-title .tribe-section-content-label, .edpsybold.tribe_community_edit .events-community-post-content label, .edpsybold.tribe_community_edit .events-community-post-content .tribe-section-content-label {
+    width: 30%;
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content, .edpsybold .category-jobs-admin fieldset, .edpsybold .category-jobs-admin div.venue, .edpsybold .category-jobs-admin div.organizer, .edpsybold .category-jobs-admin .tribe-section-content-row, .edpsybold .category-jobs-admin div.events-community-post-title, .edpsybold .category-jobs-admin .events-community-post-content, .edpsybold.tribe_community_edit fieldset, .edpsybold.tribe_community_edit div.venue, .edpsybold.tribe_community_edit div.organizer, .edpsybold.tribe_community_edit .tribe-section-content-row, .edpsybold.tribe_community_edit div.events-community-post-title, .edpsybold.tribe_community_edit .events-community-post-content {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    margin-top: var(--sp-small);
+    padding: var(--sp-xxsmall) 0;
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth table, .edpsybold .category-jobs-admin table, .edpsybold.tribe_community_edit table {
+    width: 100%;
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth h2:not(#signup-slice h2), .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-header h3, .edpsybold .category-jobs-admin h2:not(#signup-slice h2), .edpsybold .category-jobs-admin .tribe-section-header h3, .edpsybold.tribe_community_edit h2:not(#signup-slice h2), .edpsybold.tribe_community_edit .tribe-section-header h3 {
+    font-size: var(--fs-display-small);
+    color: var(--cl-light);
+    margin-top: var(--sp-xlarge);
+    margin-bottom: var(--sp-medium);
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .start-end-values .start-end-values--start, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .start-end-values .start-end-values--end, .edpsybold .category-jobs-admin .start-end-values .start-end-values--start, .edpsybold .category-jobs-admin .start-end-values .start-end-values--end, .edpsybold.tribe_community_edit .start-end-values .start-end-values--start, .edpsybold.tribe_community_edit .start-end-values .start-end-values--end {
+    display: flex;
+    gap: var(--sp-small-plus);
+    align-items: center;
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .start-end-values .start-end-values--start, .edpsybold .category-jobs-admin .start-end-values .start-end-values--start, .edpsybold.tribe_community_edit .start-end-values .start-end-values--start {
+    margin-right: var(--sp-small-plus);
+}
+
+.edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .start-end-values, .edpsybold .category-jobs-admin .start-end-values, .edpsybold.tribe_community_edit .start-end-values {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    width: 70%;
+}
+
+.edpsybold .form-block, .edpsybold .tribe-section-content, .edpsybold .tribe-events-community-details {
+    margin-top: var(--sp-small);
+}
+
+.edpsybold fieldset label small, .edpsybold fieldset label span.req, .edpsybold .events-community-post-title label small, .edpsybold .events-community-post-title label span.req, .edpsybold .events-community-post-content label small, .edpsybold .events-community-post-content label span.req, .edpsybold .wpjm-submit-block label small, .edpsybold .wpjm-submit-block label span.req {
+    font-weight: var(--fw-light);
+}
+
+.edpsybold fieldset label span.req, .edpsybold .events-community-post-title label span.req, .edpsybold .events-community-post-content label span.req, .edpsybold .wpjm-submit-block label span.req {
+    font-size: 80%;
+}
+
+.edpsybold fieldset, .edpsybold .events-community-post-title, .edpsybold .events-community-post-content, .edpsybold .wpjm-submit-block {
+    margin-top: var(--sp-medium);
+    margin-bottom: var(--sp-medium);
+}
+
+.edpsybold .field {
+    display: flex;
+    flex-direction: column;
+}
+
+.edpsybold a:focus, .edpsybold .category-jobs a.button:focus, .edpsybold .wpjm-page input.button:focus, .edpsybold .job-manager-form fieldset input.input-date:focus, .edpsybold .job-manager-form fieldset input.input-text:focus, .edpsybold .job-manager-form fieldset select:focus, .edpsybold .job-manager-form fieldset textarea:focus, .edpsybold .select2-container--default.select2-container--focus .select2-selection--multiple, .edpsybold .job-manager-form input.button:focus, .edpsybold .job-manager-application-wrapper .application .application_button:focus, .edpsybold .single_job_listing .application .application_button:focus, .edpsybold .wpjm-single-job-post a.button:focus, .edpsybold #job_preview a.button:focus, .edpsybold .mc4wp-form-fields input:focus, .edpsybold .StripeElement--focus, .edpsybold input[type=checkbox]:focus {
+    outline: 3px solid var(--cl-lightpurple);
+    outline-offset: 0;
+}
+
+.edpsybold textarea, .edpsybold input[type="text"], .edpsybold input[type="email"], .edpsybold input[type="password"], .edpsybold input[type="tel"] {
+    font-family: var(--ff);
+    font-size: var(--fs-body);
+    color: var(--cl-dark);
+    background-color: var(--cl-light);
+    border: 1px solid var(--cl-dark);
+    padding: var(--sp-small);
+    margin: var(--sp-xsmall) 0;
+    width: 65%;
+}
+
+.edpsybold textarea {
+    height: 250px;
+}
+
+.edpsybold fieldset:has(:focus), .edpsybold div.venue:has(:focus), .edpsybold div.organizer:has(:focus), .edpsybold .tribe-section-content-row:has(:focus), .edpsybold .events-community-post-title:has(:focus), .edpsybold .events-community-post-content:has(:focus) {
+    background: var(--cl-lightpurple-hover);
+}
+
+.edpsybold fieldset.account-sign-in-field:has(:focus) {
+    background: none;
+}
+
+.edpsybold input[type="text"], .edpsybold input[type="email"], .edpsybold input#create_account_email, .edpsybold input[type="password"], .edpsybold input#company_name, .edpsybold .fieldset-type-term-multiselect .field, .edpsybold .checkbox-pair {
+    width: var(--tb-medium);
+}
+
+.edpsybold input#StateProvinceText, .edpsybold input#VenueCity, .edpsybold input[type="tel"], .edpsybold input#OrganizerPhone, .edpsybold input#EventCost {
+    width: var(--tb-small);
+}
+
+.edpsybold input[type="closing_date"], .edpsybold input[type="text"].tribe-field-start_date, .edpsybold input[type="text"].tribe-field-end_date, .edpsybold input[type="text"]#EventZip {
+    width: var(--tb-xsmall);
+}
+
+.edpsybold input[type="text"]#company_website, .edpsybold input[type="text"]#application {
+    width: var(--tb-large);
+}
+
+.edpsybold textarea#post_content, .edpsybold input#post_title {
+    width: 68%;
+}
+
+.edpsybold input[type="text"].tribe-field-start_time, .edpsybold input[type="text"].tribe-field-end_time {
+    width: var(--tb-xxsmall);
+}
+
+.edpsybold .tribe-section-content-field p, .edpsybold .tribe-community-event-info p, .edpsybold .tribe-section-content p {
+    margin-bottom: 0;
+}
+
+.edpsybold .signup-content form {
+    width: 40%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.edpsybold #tribe-events-pg-template.tribe-events-pg-template {
+    background: none;
+}
+
+.edpsybold .divider {
+    margin-top: var(--sp-medium);
+    margin-bottom: var(--sp-medium);
+    overflow: hidden;
+    text-align: center;
+}
+
+.edpsybold .divider::before, .edpsybold .divider::after {
+    background-color: var(--cl-lightpurple-hover);
+    content: "";
+    display: inline-block;
+    height: 3px;
+    position: relative;
+    vertical-align: middle;
+    width: 50%;
+}
+
+.edpsybold .divider::before {
+    right: 0.5em;
+    margin-left: -50%;
+}
+
+.edpsybold .divider::after {
+    left: 0.5em;
+    margin-right: -50%;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .select2-container--default .select2-selection ul.select2-selection__rendered li {
+    list-style: none;
+    list-style-type: none;
+    margin-top: 3px;
+    margin-right: 6px;
+    margin-bottom: 3px;
+    margin-left: 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .select2-container--default .select2-selection ul.select2-selection__rendered {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .select2-container--default .select2-selection input::placeholder {
+    font-family: var(--ff);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .select2-container--default .select2-selection .select2-selection__choice .select2-selection__choice__remove {
+    margin-right: var(--sp-xxsmall);
+    color: var(--cl-light);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .select2-container--default .select2-selection .select2-selection__choice {
+    background-color: var(--cl-dark);
+    border-color: var(--cl-dark);
+    color: var(--cl-light);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .select2-container--default .select2-selection {
+    font-family: var(--ff);
+    font-size: var(--fs-body);
+    color: var(--cl-dark);
+    background-color: var(--cl-light);
+    border: 1px solid var(--cl-dark);
+    padding: var(--sp-xsmall);
+    margin: var(--sp-xsmall) 0;
+    width: 100%;
+    border-radius: 0;
+    display: flex;
+    min-height: 49px;
+}
+
+.edpsybold .wpjm-submit-block span.spinner {
+    display: none;
+}
+
+.edpsybold .wpjm-submit-block {
+    display: flex;
+    justify-content: end;
+    gap: var(--sp-home-gap);
+}
+
+.edpsybold .preview-actions.wpjm-submit-block {
+    justify-content: space-between;
+}
+
+.edpsybold .apply-block.wpjm-submit-block {
+    justify-content: start;
+}
+
+.edpsybold .select2-container--default.select2-container--focus .select2-selection--multiple {
+    outline: 3px solid var(--cl-lightpurple);
+    outline-offset: 0;
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-ico {
+    color: var(--cl-light);
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn.mce-listbox {
+    background-color: var(--cl-light);
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn:focus .mce-ico, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn:hover .mce-ico, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .qt-dfw:focus .mce-ico, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .qt-dfw:hover .mce-ico {
+    color: var(--cl-dark);
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn:focus, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn:hover, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .qt-dfw:focus, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .qt-dfw:hover {
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn.mce-active .mce-ico, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn:active .mce-ico, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .qt-dfw.active .mce-ico {
+    color: var(--cl-dark);
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn.mce-active, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .mce-btn-group .mce-btn:active, .edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar .qt-dfw.active {
+    background-color: var(--cl-lightpurple-hover);
+    color: var(--cl-dark);
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body .mce-toolbar {
+    background-color: var(--cl-dark);
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp #mceu_11-body {
+    background-color: var(--cl-dark);
+}
+
+.edpsybold div.mce-panel .mce-toolbar-grp {
+    border-bottom: none;
+}
+
+.edpsybold div.mce-panel iframe#job_description_ifr {
+    height: 500px !important;
+}
+
+.edpsybold div.mce-panel {
+    background-color: var(--cl-light);
+}
+
+.edpsybold input[type="closing_date"], .edpsybold input[type="text"].tribe-field-start_date, .edpsybold input[type="text"].tribe-field-end_date, .edpsybold input[type="text"].tribe-field-start_time, .edpsybold input[type="text"].tribe-field-end_time {
+    text-align: center;
+}
+
+.edpsybold .checkbox-pair:hover {
+    background-color: var(--cl-lightpurple-hover);
+}
+
+.edpsybold .checkbox-pair {
+    display: flex;
+    outline: 1px solid var(--cl-dark);
+    align-items: center;
+    padding-left: var(--sp-medium);
+    min-height: 48px;
+    margin-top: var(--sp-small);
+}
+
+.edpsybold input[type="file"].input-text {
+    font-size: var(--fs-body);
+    font-family: var(--ff);
+}
+
+.edpsybold .form-block .tribe-helptext {
+    margin-top: var(--sp-medium);
+}
+
+.edpsybold .form-block.form-block-job-description#form-block-job-description fieldset.fieldset-job_description label, .edpsybold .form-block.form-block-job-description#form-block-job-description .events-community-post-content label {
+    display: none;
+}
+
+.edpsybold .form-block.form-block-job-description#form-block-job-description fieldset.fieldset-job_description .field, .edpsybold .form-block.form-block-job-description#form-block-job-description .events-community-post-content .field {
+    width: 100%;
+}
+
+.edpsybold .form-block.form-block-job-description#form-block-job-description fieldset.fieldset-job_description, .edpsybold .form-block.form-block-job-description#form-block-job-description .events-community-post-content {
+    flex-direction: column;
+    margin-top: 0;
+}
+
+.edpsybold .form-block.form-block-job-description#form-block-job-description {
+    padding: var(--sp-small-plus);
+    margin-top: var(--sp-small);
+}
+
+.tribe-datetime-block .tribe-section-content-field .tribe-change-timezone {
+    width: 100%;
+}
+
+.tribe-datetime-block .tribe-section-content-field .tribe-datetime-separator {
+    display: flex;
+    align-items: center;
+}
+
+.tribe-datetime-block .tribe-section-content-field {
+    display: flex;
+    gap: var(--sp-medium);
+    flex-wrap: wrap;
+}
+
+.tribe-section-image-uploader, .aes {
+    display: none;
+}
+
+.edpsybold.edp-jobs.add-job header[role="banner"] {
+    border-bottom: none;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin fieldset .field {
+    flex-direction: column-reverse;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin fieldset.fieldset-closing_date .field, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .fieldset-cap_declaration .field {
+    flex-direction: column;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth {
+    background-color: var(--cl-jobs-primary);
+}
+
+.edpsybold.edp-jobs.add-job .select2-dropdown {
+    background-color: var(--cl-light);
+    margin-top: -2px;
+    border-radius: 0;
+    border: none;
+}
+
+.edpsybold.edp-jobs.add-job .select2-container--default .select2-results__option--highlighted[aria-selected] {
+    background-color: var(--cl-lightpurple);
+}
+
+div#ui-datepicker-div .ui-datepicker-group, .tribe-events .datepicker .ui-datepicker-group {
+    background-color: var(--cl-light);
+}
+
+div#ui-datepicker-div table, .tribe-events .datepicker table {
+    font-size: var(--fs-body-small);
+}
+
+div#ui-datepicker-div .ui-state-default, div#ui-datepicker-div .ui-widget-content .ui-state-default, div#ui-datepicker-div .ui-widget-header .ui-state-default, .tribe-events .datepicker .ui-state-default, .tribe-events .datepicker .ui-widget-content .ui-state-default, .tribe-events .datepicker .ui-widget-header .ui-state-default {
+    background-image: none;
+    border: none;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+div#ui-datepicker-div .ui-datepicker-calendar td a:link, div#ui-datepicker-div .ui-datepicker-calendar td a:visited, .tribe-events .datepicker .ui-datepicker-calendar td a:link, .tribe-events .datepicker .ui-datepicker-calendar td a:visited {
+    background-color: var(--cl-light);
+}
+
+div#ui-datepicker-div table tr td.day.focused, div#ui-datepicker-div table tr td.day:hover, div#ui-datepicker-div .ui-datepicker-calendar td a:hover, .tribe-events .datepicker table tr td.day.focused, .tribe-events .datepicker table tr td.day:hover, .tribe-events .datepicker .ui-datepicker-calendar td a:hover {
+    background-color: var(--cl-lightpurple-hover);
+}
+
+div#ui-datepicker-div, .tribe-events .datepicker {
+    background-color: var(--cl-light);
+    font-family: var(--ff);
+    border: 3px solid var(--cl-purple);
+    padding: 0 var(--sp-small-plus) var(--sp-small-plus) var(--sp-small-plus);
+}
+
+.tribe-events .datepicker table {
+    width: 100%;
+}
+
+div#ui-datepicker-div {
+    width: 395px;
+    max-width: 395px;
+}
+
+.ui-datepicker-group.ui-datepicker-group-middle, .ui-datepicker-group.ui-datepicker-group-last {
+    display: none;
+}
+
+.ui-datepicker-multi-3 .ui-datepicker-group.ui-datepicker-group-first {
+    width: 100%;
+}
+
+.edpsybold .ui-widget-content {
+    background-color: var(--cl-light);
+    background-image: none;
+}
+
+.edpsybold .ui-widget-header {
+    border: none;
+    background: none;
+}
+
+body:not(.wp-admin, .wp-core-ui) .ui-timepicker-wrapper li.ui-timepicker-selected, body:not(.wp-admin, .wp-core-ui) .ui-timepicker-wrapper .ui-timepicker-list li:hover, body:not(.wp-admin, .wp-core-ui) .ui-timepicker-wrapper .ui-timepicker-list .ui-timepicker-selected:hover {
+    background-color: var(--cl-lightpurple-hover);
+    color: var(--cl-dark);
+}
+
+body:not(.wp-admin, .wp-core-ui) .ui-timepicker-wrapper .ui-timepicker-list li {
+    text-align: center;
+}
+
+body:not(.wp-admin, .wp-core-ui) .ui-timepicker-wrapper {
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+}
+
+body:not(.wp-admin, .wp-core-ui) .datepicker.dropdown-menu, body:not(.wp-admin, .wp-core-ui) div#ui-datepicker-div, body:not(.wp-admin, .wp-core-ui) .ui-timepicker-wrapper {
+    background-color: var(--cl-light);
+    border: 5px solid var(--cl-purple);
+    border-radius: 5px;
+    box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+}
+
+body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span, body:not(.wp-admin, .wp-core-ui) .datepicker td, body:not(.wp-admin, .wp-core-ui) .datepicker th, body:not(.wp-admin, .wp-core-ui) .ui-state-default, body:not(.wp-admin, .wp-core-ui) .ui-widget-content .ui-state-default, body:not(.wp-admin, .wp-core-ui) .ui-widget-header .ui-state-default {
+    border-radius: 0;
+    font-size: var(--fs-body-small);
+    font-weight: var(--fw-extralight);
+    min-width: 48px;
+    min-height: 49px;
+}
+
+body:not(.wp-admin, .wp-core-ui) input[type="checkbox"] {
+    border-radius: 0;
+    font-size: var(--fs-body-small);
+    font-weight: var(--fw-extralight);
+    min-width: 20px;
+    min-height: 20px;
+    margin-right: 10px;
+}
+
+body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled.active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled.disabled, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled:active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled:hover, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled:hover.active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled:hover.disabled, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled:hover:active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled:hover:hover, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled:hover[disabled], body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active.disabled[disabled], body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active:active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active:hover, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active:hover.active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active:hover.disabled, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active:hover:active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active:hover:hover, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active:hover[disabled], body:not(.wp-admin, .wp-core-ui) .datepicker table tr td.active[disabled], body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled.active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled.disabled, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled:active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled:hover, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled:hover.active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled:hover.disabled, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled:hover:active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled:hover:hover, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled:hover[disabled], body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active.disabled[disabled], body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active:active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active:hover, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active:hover.active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active:hover.disabled, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active:hover:active, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active:hover:hover, body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active:hover[disabled], body:not(.wp-admin, .wp-core-ui) .datepicker table tr td span.active[disabled] {
+    background-color: var(--cl-purple);
+}
+
+body:not(.wp-admin, .wp-core-ui) .tribe-events .datepicker .dow, body:not(.wp-admin, .wp-core-ui) .tribe-events .datepicker .datepicker-switch {
+    font-weight: var(--fw-semibold);
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar-container {
+    width: 100%;
+    margin: var(--sp-large) 0 var(--sp-xxxlarge) 0;
+    min-height: 4rem;
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar {
+    counter-reset: step;
+    position: relative;
+    overflow: visible;
+    isolation: isolate;
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar li {
+    list-style-type: none;
+    float: left;
+    width: 33.33%;
+    margin-left: 0;
+    position: relative;
+    text-align: center;
+    font-weight: 600;
+    font-size: var(--fs-title-small);
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar li:before {
+    content: counter(step);
+    counter-increment: step;
+    height: 40px;
+    width: 40px;
+    line-height: 42px;
+    border: 4px solid var(--cl-light);
+    display: block;
+    text-align: center;
+    margin: 0 auto 10px auto;
+    border-radius: 50%;
+    background-color: var(--cl-jobs-primary);
+    color: var(--cl-light);
+    font-size: var(--fs-title-small);
+    position: relative;
+    z-index: 1;
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar li:after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 4px;
+    background-color: var(--cl-light);
+    top: 23px;
+    left: -50%;
+    z-index: -1;
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar li:first-child:after {
+    content: none;
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar li {
+    color: var(--cl-light);
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar li.active:before {
+    border-color: var(--cl-light);
+    background-color: var(--cl-light);
+    color: var(--cl-jobs-primary);
+}
+
+.edp-jobs.add-job.edpsybold article.category-jobs-admin .progressbar li.active+li:after {
+    background-color: var(--cl-light);
+    background-image: var(--cl-light);
+}
+
+.archive .entry-summary img {
+    width: 100%;
+    height: auto;
+}
+
+.archive.category #content, .archive.tag #content {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-home-gap);
+}
+
+.archive.category #content>header, .archive.category #content>nav, .archive.tag #content>header, .archive.tag #content>nav {
+    flex: 1 1 100%;
+}
+
+.archive.category #content>article, .archive.tag #content>article {
+    flex: 1 1 calc(50% - var(--sp-home-gap));
+}
+
+.single-post article.type-post .blog-header-block header>* {
+    width: 100%;
+}
+
+.single-post article.type-post .blog-header-block header h1 {
+    margin-bottom: var(--sp-xxlarge);
+    font-size: var(--fs-title-xlarge);
+    line-height: var(--lh-title-xlarge);
+}
+
+.single-post article.type-post .blog-header-block header {
+    flex-wrap: wrap;
+    background-size: 260px;
+    background-position: right top;
+    background-repeat: no-repeat;
+}
+
+.single-post article.type-post .blog-header-block .entry-meta .entry-date-readtime {
+    color: var(--cl-orange);
+    display: block;
+    font-weight: var(--fw-medium);
+}
+
+.single-post article.type-post .blog-header-block .entry-meta .tags--header .post-tag.post-tag--more {
+    font-weight: var(--fw-light);
+}
+
+.single-post article.type-post .blog-header-block .entry-meta .tags--header .post-tag {
+    font-weight: var(--fw-medium);
+}
+
+.single-post article.type-post .blog-header-block .entry-meta .tags--header .post-tag-wrapper {
+    margin-right: var(--sp-xsmall);
+}
+
+.single-post article.type-post .blog-header-block .entry-meta .tags--header {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.single-post article.type-post .blog-header-block .entry-meta {
+    display: flex;
+    justify-content: center;
+    padding-left: var(--sp-medium);
+    flex-direction: column;
+    gap: var(--sp-large);
+    margin-left: -106px;
+    margin-right: -24px;
+}
+
+.single-post article.type-post .blog-header-block .entry-image img.wp-post-image {
+    margin-bottom: 0;
+    object-fit: cover;
+    height: 100%;
+    width: 100%;
+    border-radius: var(--rd-large);
+}
+
+.single-post article.type-post .blog-header-block .entry-image {
+    aspect-ratio: 2 / 1;
+}
+
+.single-post article.type-post .blog-header-block {
+    background-color: var(--cl-straw);
+    padding-bottom: var(--sp-xxlarge);
+    background-image: url(../../images/edpsy-swirls-29.svg);
+    background-size: 250px;
+    background-position: right -1px;
+    background-repeat: no-repeat;
+}
+
+.single-post article.type-post .entry-content .blog-swirls-tr {
+    background-image: url(../../images/edpsy-swirls-27.svg);
+    background-position: top left;
+    background-size: 300px;
+    background-repeat: no-repeat;
+    width: 300px;
+    height: 300px;
+    grid-column: 1 / span 2;
+    margin-top: calc(-150px - var(--sp-xxlarge));
+    margin-left: -300px;
+    z-index: 0;
+}
+
+.single-post article.type-post .entry-content .entry-author--top img.avatar {
+    margin-bottom: 0;
+}
+
+.single-post article.type-post .entry-content .entry-author--top .author-name a:link, .single-post article.type-post .entry-content .entry-author--top .author-name a:visited {
+    text-decoration: none;
+}
+
+.single-post article.type-post .entry-content .entry-author--top .author-name {
+    font-size: var(--fs-body);
+    line-height: var(--lh-body);
+    text-align: center;
+}
+
+.single-post article.type-post .entry-content .entry-author--top {
+    margin-top: -125px;
+}
+
+.single-post article.type-post .entry-content {
+    margin-top: var(--sp-xxlarge);
+}
+
+.single-post article.type-post hr {
+    color: var(--cl-dark-hover);
+}
+
+.single-post article.type-post .entry-footer .tag-links .tag-title {
+    display: flex;
+    align-items: center;
+    font-weight: var(--fw-semibold);
+}
+
+.single-post article.type-post .entry-footer .tag-links .tag-items {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.single-post article.type-post .entry-footer .tag-links i {
+    margin-top: 8px;
+    margin-right: var(--sp-xsmall);
+    color: var(--cl-blog-primary);
+    font-size: var(--fs-title-small);
+}
+
+.single-post article.type-post .entry-footer .tag-links a {
+    margin: var(--sp-xsmall);
+    padding: 0 var(--sp-xsmall);
+    background-color: var(--cl-lightpurple-hover);
+    border-radius: 4px;
+}
+
+.single-post article.type-post .entry-footer .tag-links a:link, .single-post article.type-post .entry-footer .tag-links a:visited {
+    color: var(--cl-dark);
+    text-decoration: none;
+}
+
+.single-post article.type-post .entry-footer .tag-links a:hover, .single-post article.type-post .entry-footer .tag-links a:active {
+    outline: 2px solid var(--cl-medpurple);
+    box-shadow: none;
+}
+
+.single-post article.type-post .entry-footer .tag-links {
+    margin-bottom: var(--sp-large);
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--sp-small);
+    margin-left: -49px;
+}
+
+.single-post article.type-post .entry-footer .page-divider {
+    border-top: 2px solid var(--cl-medpurple-hover);
+    padding-top: var(--sp-large);
+}
+
+.single-post article.type-post .entry-footer {
+    border-top: 2px solid var(--cl-medpurple-hover);
+    margin-top: var(--sp-large);
+    padding-top: var(--sp-large);
+}
+
+.single-post article.type-post .entry-footer .author-info .author-avatar img, .archive.author .author-info .author-avatar img {
+    width: 125px;
+    height: 125px;
+    border-radius: 50%;
+    object-fit: cover;
+    object-position: top center;
+}
+
+.single-post article.type-post .entry-footer .author-info .author-avatar, .archive.author .author-info .author-avatar {
+    width: 125px;
+    height: 125px;
+    padding-right: var(--sp-small);
+}
+
+.single-post article.type-post .entry-footer .author-info {
+    margin-top: var(--sp-large);
+    margin-bottom: var(--sp-xlarge);
+}
+
+#container article.type-post .authors-section .author-avatar img.wp-post-image, #container article.type-post .authors-section .author-avatar img, .archive.author .author-avatar img.wp-post-image, .archive.author .author-avatar img, .author-info .author-avatar img.wp-post-image, .author-info .author-avatar img {
+    border-radius: 50%;
+    object-fit: cover;
+    object-position: top center;
+    outline: none !important;
+}
+
+#container article.type-post .authors-section .author-avatar, .archive.author .author-avatar, .author-info .author-avatar {
+    height: auto;
+    margin: 0 auto;
+    overflow: hidden;
+}
+
+.archive.author .archive-meta .author-description p.author-bio {
+    margin-bottom: 0;
+}
+
+.archive.author .archive-meta .author-description {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.archive.author .archive-meta {
+    background-color: var(--cl-lightpurple-hover);
+    padding: var(--sp-medium) 0;
+    margin: var(--sp-large) 0 var(--sp-xlarge) 0;
+    border-radius: var(--rd-large);
+}
+
+.archive.author .promo-2 {
+    display: none;
+}
+
+#container article.type-post .authors-section.author-count-1 .author-avatar img.wp-post-image, #container article.type-post .authors-section.author-count-1 .author-avatar img {
+    width: 150px;
+    height: 150px;
+}
+
+#container article.type-post .authors-section.author-count-1 .author-avatar {
+    max-width: 150px;
+}
+
+#container article.type-post .authors-section.author-count-2 .author-avatars .author-avatar img, #container article.type-post .authors-section.author-count-2 .author-avatars .author-avatar img.wp-post-image {
+    width: 110px;
+    height: 110px;
+}
+
+#container article.type-post .authors-section.author-count-2 .author-avatars .author-avatar {
+    max-width: 110px;
+    max-height: 110px;
+}
+
+#container article.type-post .authors-section.author-count-2 .author-avatars .author-1 {
+    position: relative;
+    z-index: 1;
+}
+
+#container article.type-post .authors-section.author-count-2 .author-avatars .author-2 {
+    position: relative;
+    z-index: 2;
+    margin-left: -180px;
+}
+
+#container article.type-post .authors-section.author-count-2 .author-avatars {
+    position: relative;
+}
+
+#container article.type-post .authors-section.author-count-3 .author-avatars .author-avatar img, #container article.type-post .authors-section.author-count-3 .author-avatars .author-avatar img.wp-post-image {
+    width: 110px;
+    height: 110px;
+}
+
+#container article.type-post .authors-section.author-count-3 .author-avatars .author-avatar {
+    max-width: 110px;
+    max-height: 110px;
+}
+
+#container article.type-post .authors-section.author-count-3 .author-avatars .author-1 {
+    position: relative;
+    z-index: 1;
+}
+
+#container article.type-post .authors-section.author-count-3 .author-avatars .author-2 {
+    position: relative;
+    z-index: 2;
+    margin-left: -25px;
+}
+
+#container article.type-post .authors-section.author-count-3 .author-avatars .author-3 {
+    position: relative;
+    z-index: 3;
+    margin-left: -25px;
+}
+
+#container article.type-post .authors-section.author-count-3 .author-avatars {
+    position: relative;
+}
+
+#container article.type-post .authors-section.author-count-4 .author-avatars .author-avatar img, #container article.type-post .authors-section.author-count-4 .author-avatars .author-avatar img.wp-post-image {
+    width: 110px;
+    height: 110px;
+}
+
+#container article.type-post .authors-section.author-count-4 .author-avatars .author-avatar {
+    max-width: 110px;
+    max-height: 110px;
+}
+
+#container article.type-post .authors-section.author-count-4 .author-avatars .author-1 {
+    position: relative;
+    z-index: 1;
+}
+
+#container article.type-post .authors-section.author-count-4 .author-avatars .author-2 {
+    position: relative;
+    z-index: 2;
+    margin-left: -25px;
+}
+
+#container article.type-post .authors-section.author-count-4 .author-avatars .author-3 {
+    position: relative;
+    z-index: 3;
+    margin-top: -15px;
+}
+
+#container article.type-post .authors-section.author-count-4 .author-avatars .author-4 {
+    position: relative;
+    z-index: 4;
+    margin-left: -25px;
+    margin-top: -15px;
+}
+
+#container article.type-post .authors-section.author-count-4 .author-avatars {
+    position: relative;
+    flex-wrap: wrap;
+    max-width: 240px;
+    margin: 0 auto;
+    margin-bottom: var(--sp-small);
+}
+
+#container article.type-post .authors-section .author-deco {
+    width: 80px;
+    height: 50px;
+    margin-top: var(--sp-medium);
+    background-image: url(../../images/edpsy-swirls-element-2.svg);
+    background-position: top left;
+    background-size: 80px;
+    background-repeat: no-repeat;
+}
+
+#container article.type-post .authors-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.author-avatars {
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--sp-small);
+}
+
+.archive.category-blog article.type-post a:hover h2, .archive.category-blog article.type-post a:active h2 {
+    color: var(--cl-purple);
+}
+
+.archive.category-blog article.type-post a:link, .archive.category-blog article.type-post a:visited {
+    color: var(--cl-dark);
+}
+
+.archive.category-blog article.type-post h2.entry-title {
+    margin-bottom: var(--sp-small);
+}
+
+.tribe-common .tribe-common-l-container {
+    padding: 0;
+}
+
+.post-type-archive-tribe_events #container .tribe-common-l-container, .edpsybold.tribe_community_edit #container .tribe-common-l-container {
+    margin-top: var(--sp-small);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-header__messages .tribe-events-c-messages__message a:link, .post-type-archive-tribe_events #container .tribe-events-header__messages .tribe-events-c-messages__message a:visited, .edpsybold.tribe_community_edit #container .tribe-events-header__messages .tribe-events-c-messages__message a:link, .edpsybold.tribe_community_edit #container .tribe-events-header__messages .tribe-events-c-messages__message a:visited {
+    color: var(--cl-light);
+    text-decoration: underline;
+}
+
+.post-type-archive-tribe_events #container .tribe-events-header__messages .tribe-events-c-messages__message a:hover, .post-type-archive-tribe_events #container .tribe-events-header__messages .tribe-events-c-messages__message a:active, .edpsybold.tribe_community_edit #container .tribe-events-header__messages .tribe-events-c-messages__message a:hover, .edpsybold.tribe_community_edit #container .tribe-events-header__messages .tribe-events-c-messages__message a:active {
+    color: var(--cl-light);
+    text-decoration: none;
+}
+
+.post-type-archive-tribe_events #container .tribe-events-header__messages .tribe-events-c-messages__message, .edpsybold.tribe_community_edit #container .tribe-events-header__messages .tribe-events-c-messages__message {
+    gap: var(--sp-small);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-header__messages, .edpsybold.tribe_community_edit #container .tribe-events-header__messages {
+    padding: var(--sp-xsmall) var(--sp-medium);
+    border: 1px solid var(--cl-light);
+    background: var(--cl-dark-50);
+    margin-bottom: var(--sp-medium);
+    margin-left: 0;
+    width: fit-content;
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-top-bar .tribe-events-c-view-selector .tribe-common-c-svgicon--list.tribe-events-c-view-selector__button-icon-svg, .edpsybold.tribe_community_edit #container .tribe-events-c-top-bar .tribe-events-c-view-selector .tribe-common-c-svgicon--list.tribe-events-c-view-selector__button-icon-svg {
+    color: var(--cl-light);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-top-bar .tribe-events-c-view-selector, .edpsybold.tribe_community_edit #container .tribe-events-c-top-bar .tribe-events-c-view-selector {
+    display: none;
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-top-bar .tribe-events-c-view-selector__content, .edpsybold.tribe_community_edit #container .tribe-events-c-top-bar .tribe-events-c-view-selector__content {
+    background-color: var(--cl-light);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-top-bar, .edpsybold.tribe_community_edit #container .tribe-events-c-top-bar {
+    padding: var(--sp-xsmall) var(--sp-small);
+    border: 1px solid var(--cl-light);
+    background: var(--cl-dark-50);
+    margin-bottom: var(--sp-medium);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-calendar-list__month-separator .tribe-events-calendar-list__month-separator-text, .edpsybold.tribe_community_edit #container .tribe-events-calendar-list__month-separator .tribe-events-calendar-list__month-separator-text {
+    font-size: var(--fs-title-large);
+    line-height: var(--lh-title-large);
+    font-weight: var(--fw-semibold);
+    height: auto;
+    margin-bottom: var(--sp-small);
+    padding-bottom: var(--sp-small);
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a:hover, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a:hover {
+    filter: brightness(75%);
+    opacity: 1;
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-weekday, .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-month, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-weekday, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-month {
+    font-size: var(--fs-title-small);
+    font-weight: var(--fw-medium);
+    color: var(--cl-dark);
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-daynum, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-daynum {
+    font-size: var(--fs-title-large);
+    font-weight: var(--fw-semibold);
+    color: var(--cl-dark);
+    padding: var(--sp-small) 0;
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime {
+    padding: var(--sp-medium);
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag {
+    background-color: var(--cl-yellow);
+    min-width: 105px;
+    margin-right: var(--sp-small);
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-header h3, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-header h3 {
+    font-size: var(--fs-title-small);
+    font-weight: var(--fw-semibold);
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-header, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-header {
+    padding: var(--sp-medium);
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+    margin-right: var(--sp-small);
+    flex-grow: 3;
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-meta .epd-events-calendar-list__event-venue .epd-events-calendar-list__event-venue-address, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-meta .epd-events-calendar-list__event-venue .epd-events-calendar-list__event-venue-address {
+    font-style: normal;
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-meta .epd-events-calendar-list__event-venue, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-meta .epd-events-calendar-list__event-venue {
+    margin-bottom: var(--sp-small);
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-meta, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-meta {
+    padding: var(--sp-medium);
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+    min-width: 240px;
+    font-style: normal;
+    font-weight: var(--fw-semibold);
+    font-size: var(--fs-body);
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: var(--sp-large);
+    padding-bottom: 0;
+}
+
+.post-type-archive-tribe_events #container .edp-events-calendar-list__event-row--featured a .edp-events-calendar-list__event-header, .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row--featured a .edp-events-calendar-list__event-meta, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row--featured a .edp-events-calendar-list__event-header, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row--featured a .edp-events-calendar-list__event-meta {
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+    border: 1px solid var(--cl-light);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-nav__list :disabled, .post-type-archive-tribe_events #container .tribe-events-c-nav__list :disabled:hover, .edpsybold.tribe_community_edit #container .tribe-events-c-nav__list :disabled, .edpsybold.tribe_community_edit #container .tribe-events-c-nav__list :disabled:hover {
+    color: var(--cl-light);
+    opacity: var(--op-strong);
+    font-size: var(--fs-body);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-nav__list svg.tribe-common-c-svgicon--caret-left, .edpsybold.tribe_community_edit #container .tribe-events-c-nav__list svg.tribe-common-c-svgicon--caret-left {
+    margin-right: var(--sp-small);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-nav__list svg.tribe-common-c-svgicon--caret-right, .edpsybold.tribe_community_edit #container .tribe-events-c-nav__list svg.tribe-common-c-svgicon--caret-right {
+    margin-left: var(--sp-small);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-nav__list svg, .edpsybold.tribe_community_edit #container .tribe-events-c-nav__list svg {
+    fill: var(--cl-light);
+    height: 15px;
+    display: inline-block;
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-nav__list, .edpsybold.tribe_community_edit #container .tribe-events-c-nav__list {
+    font-weight: var(--fw-semibold);
+}
+
+.post-type-archive-tribe_events #container .tribe-events-c-subscribe-dropdown__container, .edpsybold.tribe_community_edit #container .tribe-events-c-subscribe-dropdown__container {
+    display: none;
+}
+
+.post-type-archive-tribe_events #container .event-disclaimer p, .edpsybold.tribe_community_edit #container .event-disclaimer p {
+    max-width: 800px;
+    margin-bottom: var(--sp-medium);
+}
+
+.post-type-archive-tribe_events #container .event-disclaimer, .edpsybold.tribe_community_edit #container .event-disclaimer {
+    margin: var(--sp-xlarge) 0 var(--sp-xxlarge) 0;
+}
+
+.post-type-archive-tribe_events #container .tribe-events .tribe-events-view-loader, .edpsybold.tribe_community_edit #container .tribe-events .tribe-events-view-loader {
+    background-color: var(--cl-dark);
+    opacity: var(--op-light);
+    left: -300px;
+    right: -300px;
+}
+
+.post-type-archive-tribe_events #container #tribe-community-events .events-promo h2, .edpsybold.tribe_community_edit #container #tribe-community-events .events-promo h2 {
+    font-size: var(--fs-title-medium) !important;
+    margin-top: var(--sp-medium) !important;
+}
+
+.post-type-archive-tribe_events #container #tribe-community-events .events-promo, .edpsybold.tribe_community_edit #container #tribe-community-events .events-promo {
+    padding: var(--sp-xsmall) var(--sp-medium);
+    border: 1px solid var(--cl-light);
+    background: var(--cl-dark-50);
+    margin-bottom: var(--sp-medium);
+}
+
+.post-type-archive-tribe_events #container #recurrence-changed-row, .edpsybold.tribe_community_edit #container #recurrence-changed-row {
+    display: none;
+}
+
+.post-type-archive-tribe_events #container .tribe-events-community-footer, .edpsybold.tribe_community_edit #container .tribe-events-community-footer {
+    margin-top: var(--sp-medium);
+    display: flex;
+    justify-content: end;
+}
+
+.post-type-archive-tribe_events #container .tribe-events-community-details#event_captcha, .edpsybold.tribe_community_edit #container .tribe-events-community-details#event_captcha {
+    padding-top: var(--sp-medium);
+    padding-left: calc(30% + var(--sp-medium));
+    margin-top: var(--sp-large);
+}
+
+.post-type-archive-tribe_events #container .tribe-change-timezone, .post-type-archive-tribe_events #container #event-timezone, .edpsybold.tribe_community_edit #container .tribe-change-timezone, .edpsybold.tribe_community_edit #container #event-timezone {
+    display: none;
+}
+
+.post-type-archive-tribe_events #container, .edpsybold.tribe_community_edit #container {
+    color: var(--cl-light);
+    background-color: var(--cl-events-primary);
+    background-image: url(../../images/edpsy-swirls-03.svg);
+    background-position: right -74px;
+    background-size: 750px;
+    background-repeat: no-repeat;
+}
+
+.post-type-archive-tribe_events header.my-events-header .tribe-button, .edpsybold.tribe_community_edit header.my-events-header .tribe-button {
+    display: none;
+}
+
+.post-type-archive-tribe_events .tribe-events-calendar-month__header .tribe-events-calendar-month__header-column, .edpsybold.tribe_community_edit .tribe-events-calendar-month__header .tribe-events-calendar-month__header-column {
+    padding-left: 16px;
+}
+
+.post-type-archive-tribe_events .tribe-events-calendar-month__body .tribe-events-calendar-month__day-date-daynum a.tribe-events-calendar-month__day-date-link, .edpsybold.tribe_community_edit .tribe-events-calendar-month__body .tribe-events-calendar-month__day-date-daynum a.tribe-events-calendar-month__day-date-link {
+    border-radius: 100%;
+    background: var(--cl-light);
+    width: 27px;
+    display: block;
+    margin-left: -7px;
+    padding: 0 7px;
+}
+
+.post-type-archive-tribe_events .tribe-events-calendar-month__body .tribe-events-calendar-month__day-date-daynum, .edpsybold.tribe_community_edit .tribe-events-calendar-month__body .tribe-events-calendar-month__day-date-daynum {
+    color: var(--cl-light);
+}
+
+.post-type-archive-tribe_events .tribe-events-calendar-month__body, .edpsybold.tribe_community_edit .tribe-events-calendar-month__body {
+    background: var(--cl-dark-50);
+}
+
+.post-type-archive-tribe_events .tribe-common--breakpoint-medium.tribe-events .tribe-events-calendar-month__body, .edpsybold.tribe_community_edit .tribe-common--breakpoint-medium.tribe-events .tribe-events-calendar-month__body {
+    border-top: 1px solid var(--cl-light);
+    border-left: 1px solid var(--cl-light);
+}
+
+.post-type-archive-tribe_events .tribe-community-notice p, .edpsybold.tribe_community_edit .tribe-community-notice p {
+    color: var(--cl-dark);
+    font-size: var(--fs-title-medium);
+    line-height: var(--lh-title-medium);
+    font-weight: var(--fw-medium);
+}
+
+.post-type-archive-tribe_events .tribe-community-notice, .edpsybold.tribe_community_edit .tribe-community-notice {
+    margin: var(--sp-xxxlarge) 0 50% 0;
+    background-color: var(--cl-light);
+    padding: var(--sp-xlarge) var(--sp-xlarge) var(--sp-large) var(--sp-xlarge);
+}
+
+.single-tribe_events .meta-item li {
+    padding-bottom: var(--sp-xsmall);
+}
+
+.single-tribe_events .meta-item .tribe-events-gmap {
+    display: none;
+}
+
+.single-tribe_events .tribe-events-notices {
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+    padding: var(--sp-small);
+    margin-bottom: var(--sp-xlarge);
+}
+
+.single-tribe_events .page-cta {
+    display: flex;
+    justify-content: start;
+    margin-top: var(--sp-large);
+}
+
+.single-tribe_events .tribe-events-venue-map {
+    margin-top: var(--sp-large);
+}
+
+.single-tribe_events .tribe-events-after-html .event-disclaimer {
+    padding-left: var(--sp-large);
+    padding-right: var(--sp-large);
+}
+
+.single-tribe_events .tribe-events-after-html {
+    padding: var(--sp-xlarge) 0 var(--sp-large) 0;
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+}
+
+.single-tribe_events.event-cat-on-demand .on-demand-icon {
+    color: var(--cl-yellow);
+    margin-left: var(--sp-xsmall);
+}
+
+.single-tribe_events.event-cat-on-demand .meta-item.meta-item--date {
+    display: none !important;
+}
+
+.single-tribe_events.event-cat-on-demand .tribe-events-notices {
+    display: none;
+}
+
+.edp-events-calendar-list__event-row a:hover {
+    opacity: var(--op-light);
+}
+
+.edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-weekday, .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-month {
+    font-size: var(--fs-title-small);
+    font-weight: var(--fw-medium);
+    color: var(--cl-dark);
+}
+
+.edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-daynum {
+    font-size: var(--fs-title-large);
+    font-weight: var(--fw-semibold);
+    color: var(--cl-dark);
+    min-height: 50px;
+    padding: var(--sp-small) 0 0 0;
+}
+
+.edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime {
+    padding: var(--sp-medium);
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+
+.edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag {
+    background-color: var(--cl-yellow);
+    min-width: 105px;
+    margin-right: var(--sp-small);
+}
+
+.edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-header h3 {
+    font-size: var(--fs-body);
+    line-height: var(--lh-body);
+    font-weight: var(--fw-semibold);
+}
+
+.edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-header {
+    padding: var(--sp-medium);
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+    margin-right: var(--sp-small);
+    flex-grow: 3;
+}
+
+.edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-meta .epd-events-calendar-list__event-venue .epd-events-calendar-list__event-venue-address {
+    font-style: normal;
+}
+
+.edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-meta .epd-events-calendar-list__event-venue {
+    margin-bottom: var(--sp-small);
+}
+
+.edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-meta {
+    padding: var(--sp-medium);
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+    min-width: var(--gs-3);
+    font-style: normal;
+    font-weight: var(--fw-semibold);
+    font-size: var(--fs-body);
+}
+
+.edp-events-calendar-list__event-row a .edp-event-title-and-meta {
+    display: flex;
+    width: 100%;
+}
+
+.edp-events-calendar-list__event-row a {
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: var(--sp-medium);
+}
+
+.edp-events-calendar-list__event-row--featured a .edp-events-calendar-list__event-header, .edp-events-calendar-list__event-row--featured a .edp-events-calendar-list__event-meta {
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+    border: 1px solid var(--cl-light);
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) h2:not(.signup-content h2) {
+    font-size: var(--fs-display-medium);
+    line-height: var(--lh-display-medium);
+    margin: var(--sp-xxlarge) 0 var(--sp-large) 0;
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-community-events-add-event {
+    margin-bottom: var(--sp-xxlarge);
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-event-list-search {
+    display: none;
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .table-menu-hidden {
+    left: -999em;
+    right: auto;
+    display: none;
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .table-menu ul li label:hover, body.tribe_community_list:not(.wp-admin, .wp-core-ui) .table-menu ul li label:focus {
+    background-color: var(--cl-lightpurple-hover);
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .table-menu ul li label input[type="checkbox"] {
+    min-width: 12px;
+    min-height: 0;
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .table-menu ul li label {
+    display: flex;
+    align-items: center;
+    padding: var(--sp-small) var(--sp-small);
+    gap: var(--sp-small);
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .table-menu {
+    background-color: var(--tec-color-background);
+    border: 3px solid var(--cl-purple);
+    left: -3px;
+    margin-top: 6px;
+    padding: var(--tec-spacer-2);
+    position: absolute;
+    width: 200px;
+    z-index: 1;
+    background-color: var(--cl-light);
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-nav-top {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-nav .table-menu-wrapper {
+    display: inline-block;
+    padding: 0;
+    position: relative;
+    z-index: 1;
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-community-events-list thead {
+    font-weight: var(--fw-semibold);
+    border-bottom: 1px solid var(--cl-dark);
+    text-align: left;
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-community-events-list th, body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-community-events-list td {
+    padding: var(--sp-small) var(--sp-small);
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-community-events-list img {
+    max-width: 14px;
+}
+
+body.tribe_community_list:not(.wp-admin, .wp-core-ui) .tribe-community-events-list {
+    margin-top: var(--sp-large);
+    margin-bottom: 20%;
+}
+
+.edp-jobs.job-listings-page #container {
+    background-color: var(--cl-jobs-primary);
+}
+
+.edp-jobs.job-listings-page .entry-content+* {
+    grid-column: 2 / span 10;
+}
+
+.edp-jobs.job-listings-page .entry-content .job_filters {
+    display: none;
+}
+
+.edp-jobs.job-listings-page .entry-content div.job_listings {
+    grid-column: 2 / span 10;
+    margin-bottom: var(--sp-xlarge);
+}
+
+.edp-jobs.job-listings-page .entry-content .no_job_listings_found-text {
+    font-size: var(--fs-title-medium);
+    font-weight: var(--fw-semibold);
+    line-height: var(--lh-display-small);
+    color: var(--cl-light);
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a:hover {
+    opacity: var(--op-light);
+    box-shadow: none;
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing-logo img {
+    max-width: 80%;
+    height: auto;
+    max-height: calc(var(--lv-listing-height) - (2* var(--sp-small)));
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing-logo {
+    grid-column: 1 / span 2;
+    padding: var(--sp-small) 0 var(--sp-small) var(--sp-small);
+    justify-content: center;
+    align-content: center;
+    display: flex;
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing--details-meta {
+    grid-column: 3 / span 8;
+    display: grid;
+    grid-template-columns: subgrid;
+    height: 100%;
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing-details .job-title h2 {
+    font-size: var(--fs-title-small);
+    color: var(--cl-dark);
+    font-weight: var(--fw-semibold);
+    padding-bottom: var(--sp-small);
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing-details .company {
+    font-size: var(--fs-body);
+    color: var(--cl-dark);
+    font-weight: var(--fw-medium);
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing-details {
+    grid-column: 1 / span 5;
+    padding: var(--sp-small) 0;
+    align-content: center;
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing-meta {
+    grid-column: 6 / span 3;
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+    padding: var(--sp-small) var(--sp-medium) var(--sp-small) var(--sp-medium);
+    height: 100%;
+    align-content: center;
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li a {
+    display: grid;
+    grid-template-columns: repeat(10, 1fr);
+    grid-column-gap: 24px;
+    background-color: var(--cl-light);
+    min-height: var(--lv-listing-height);
+    margin-bottom: var(--sp-medium);
+    align-items: center;
+}
+
+.edp-jobs.job-listings-page .entry-content ul.job_listings li {
+    padding-left: 0;
+}
+
+.edp-jobs.job-listings-page .entry-content {
+    grid-template-columns: repeat(12, 1fr);
+    display: grid;
+    grid-column-gap: 24px;
+    max-width: var(--lv-full-width);
+}
+
+.edp-jobs.job-listings-page ul.job_listings.loading li.dummy-job {
+    display: grid;
+    grid-template-columns: repeat(10, 1fr);
+    grid-column-gap: 24px;
+    min-height: var(--lv-listing-height);
+    margin-bottom: var(--sp-medium);
+    align-items: center;
+    animation: skeleton-loading 1s linear infinite alternate;
+    color: transparent;
+}
+
+@keyframes skeleton-loading {
+    0% {
+                background-color: #F5F5F5;
+                
+            }
+
+            100% {
+                background-color: #E2E2E2;
+                
+            }
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .job_listing_preview article.type-job_listing h2 {
+    color: var(--cl-dark);
+    font-size: var(--fs-title-medium);
+    margin: 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .job_listing_preview article.type-job_listing {
+    background-color: var(--cl-light);
+    border: solid 3px var(--cl-dark);
+    padding-bottom: var(--sp-large);
+}
+
+.wpbdp-notice.wpbdp-upgrade-bar.wpbdp-inline-notice {
+    display: none;
+}
+
+body>.job-manager-error {
+    display: none;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .fieldset-login_required {
+    min-width: 150px;
+    margin-top: var(--sp-small);
+    border-right: solid 4px var(--cl-jobs-primary);
+    margin-left: var(--sp-medium);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin fieldset.account-sign-in-field {
+    display: block;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .edp-jobs-createaccount {
+    margin-top: var(--sp-medium);
+    margin-left: var(--sp-xxlarge);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .option-block-or {
+    float: right;
+    margin-right: -19px;
+    padding: 0 6px 3px 6px;
+    margin-top: -53px;
+    font-size: 18px;
+    background: var(--cl-light);
+    border-radius: 20px;
+    border: var(--cl-jobs-primary) 2px solid;
+    font-weight: 500;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .fieldset-logged_in .option-block-or {
+    display: none;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin {
+    display: flex;
+    padding-bottom: var(--sp-medium);
+    margin-bottom: var(--sp-medium);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth p.new-job-warning a, .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.job-manager-error a, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .job-manager-info a {
+    background-color: var(--cl-light);
+    padding: 0 var(--sp-xsmall);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth p.new-job-warning, .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.job-manager-error, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .job-manager-info {
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+    padding: var(--sp-large) var(--sp-large) var(--sp-large) var(--sp-xlarge);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .fieldset-logged_in .field.account-sign-in {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .fieldset-logged_in p.signout-button {
+    margin: 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .fieldset-logged_in {
+    padding-left: var(--sp-small);
+    padding-right: var(--sp-medium);
+    width: 100%;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .signin-text {
+    padding-top: var(--sp-medium);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .job-manager-uploaded-files .job-manager-uploaded-file-preview {
+    display: flex;
+    gap: var(--sp-small);
+    align-items: flex-end;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .job-manager-uploaded-files {
+    margin: var(--sp-medium) 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-cols {
+    display: flex;
+    margin-bottom: 3rem;
+    background-color: var(--cl-light);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1 h2, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col2 h2 {
+    font-size: var(--fs-title-medium);
+    color: var(--cl-dark);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col2 {
+    padding: var(--sp-small) var(--sp-large) var(--sp-large) var(--sp-large);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1 {
+    border-right: solid 4px var(--cl-jobs-primary);
+    width: 60%;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .job_listing_stripe_checkout_form fieldset label {
+    padding-bottom: 0.55rem;
+    margin-top: 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form input[type="text"]#stripe-cardholder-name {
+    height: 40px;
+    width: 100%;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .StripeElement {
+    border: 1px solid var(--cl-dark);
+    border-radius: 0;
+    margin: 0;
+    box-shadow: none;
+    background-color: var(--cl-light);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .stripe-badge {
+    margin-left: 1rem;
+    margin-top: 0.2rem;
+    position: absolute;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-block-top-text {
+    padding-top: 0.75rem;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset.fieldset-name {
+    margin-bottom: 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset .job-details-block label.job-listing {
+    padding-top: 0;
+    width: 100%;
+    text-align: right;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset .job-details-block {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    padding: var(--sp-medium);
+    margin: 1rem 0;
+    background: var(--cl-light);
+    align-items: center;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset {
+    align-items: start;
+    flex-direction: column;
+    gap: 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .payment-details-name-description {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    width: 50%;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset .job-details-block label:not(.full-line-checkbox-field label), .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset .job-details-block .field {
+    width: 50%;
+    text-align: right;
+    padding-right: 30px;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset label:not(.full-line-checkbox-field label) {
+    width: 70%;
+    padding: 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset div.field:not(.full-line-checkbox-field) {
+    width: 90%;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-block-or {
+    float: right;
+    margin-right: -55px;
+    padding: 0 6px 3px 6px;
+    margin-top: -10rem;
+    font-size: 18px;
+    background: var(--cl-light);
+    border-radius: 20px;
+    border: var(--cl-jobs-primary) 2px solid;
+    font-weight: 500;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .item-cost {
+    font-size: 2rem;
+    margin-left: 3rem;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form h2 {
+    line-height: 2rem;
+    margin-top: 2rem;
+}
+
+.edpsybold #container.edp-fullwidth .category-jobs ul.fa-features li i, .edpsybold #container.edp-fullwidth .category-jobs ul.fa-features li svg {
+    color: var(--cl-jobs-dark);
+    padding-top: 0.3rem;
+}
+
+.edpsybold #container.edp-fullwidth .category-jobs ul.fa-features li.fali {
+    margin-bottom: 2rem;
+    list-style-type: none;
+}
+
+.edpsybold #container.edp-fullwidth .category-jobs ul.fa-features li ul li {
+    margin-bottom: 0;
+}
+
+.edpsybold #container.edp-fullwidth .category-jobs ul.fa-features {
+    margin: var(--sp-medium) var(--sp-xxlarge) 0 var(--sp-xxlarge);
+    position: relative;
+}
+
+.edpsybold #container.edp-fullwidth .category-jobs .fa-ul>li {
+    position: relative;
+}
+
+.edpsybold #container.edp-fullwidth .category-jobs .fa-ul {
+    padding-left: 0;
+}
+
+.edpsybold #container.edp-fullwidth .category-jobs .fa-li {
+    left: -62px;
+    position: absolute;
+    text-align: center;
+    width: 50px;
+    line-height: inherit;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .job-manager-message h2 {
+    color: var(--cl-dark);
+    margin-top: 0;
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .job-manager-message .success-icon {
+    margin-top: var(--sp-small-plus);
+    margin-left: var(--sp-medium);
+}
+
+.edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin .job-manager-message {
+    display: flex;
+    background-color: var(--cl-light);
+    margin-bottom: 30%;
+    margin-top: var(--sp-large);
+}
+
+.success-icon {
+    margin-top: 2rem;
+}
+
+.success-message h2 {
+    margin-top: 0;
+}
+
+#job-manager-job-dashboard td.company img {
+    max-width: 150px;
+    max-height: 120px;
+}
+
+#job-manager-job-dashboard td.company {
+    vertical-align: middle;
+}
+
+#content .job-manager-uploaded-file-preview img {
+    max-width: 280px;
+}
+
+#job-manager-job-dashboard th.stats, #job-manager-job-dashboard td.stats {
+    display: none;
+}
+
+.wpjm-dashboard .job-post-promo, .wpjm-dashboard .progressbar-container {
+    display: none;
+}
+
+#job-manager-job-dashboard table td, #job-manager-job-dashboard table th {
+    padding: 1rem;
+    border: none;
+}
+
+#job-manager-job-dashboard table tr {
+    border-top: solid 1px rgba(0, 0, 0, .12);
+}
+
+#job-manager-job-dashboard table {
+    border: 1px solid rgba(0, 0, 0, .12);
+}
+
+table.job-manager-jobs th.filled, table.job-manager-jobs td.filled {
+    display: none;
+}
+
+table.job-manager-jobs th, #content table.job-manager-jobs tr td, #job-manager-job-dashboard table .applications, #job-manager-job-dashboard table .expires, #job-manager-job-dashboard table .filled {
+    text-align: left;
+}
+
+#job-manager-job-dashboard table thead {
+    background-color: rgba(0, 0, 0, .04);
+}
+
+#job-manager-job-dashboard table tbody tr:hover {
+    outline: solid 1px rgba(0, 0, 0, .04);
+    background-color: rgba(0, 0, 0, 0.01);
+}
+
+#job-manager-job-dashboard table ul.job-dashboard-actions li:after {
+    content: "|";
+    color: var(--cl-dark);
+}
+
+#job-manager-job-dashboard table ul.job-dashboard-actions li:last-of-type:after {
+    content: none;
+}
+
+table.job-manager-jobs .job_title small {
+    border: #999 solid 1px;
+    color: #999;
+    padding: 0.05rem 0.3rem;
+    font-weight: 400;
+    font-size: 0.8rem;
+    min-width: 20%;
+    text-align: center;
+}
+
+table.job-manager-jobs .job-title a, .dashboard-job-title {
+    font-weight: 300;
+    margin-right: 0.5rem;
+}
+
+#job-manager-job-dashboard table ul.job-dashboard-actions li {
+    font-weight: 300;
+}
+
+#job-manager-job-dashboard table.job-manager-jobs .job_title small.dashboard-live {
+    background-color: var(--cl-red-25);
+    color: var(--cl-red);
+}
+
+table.job-manager-jobs .job_title {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: var(--sp-xsmall);
+}
+
+table.job-manager-jobs ul.job-dashboard-actions {
+    flex-basis: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-xsmall);
+}
+
+.wpjm-dashboard .job-manager-message a:link, .wpjm-dashboard .job-manager-message a:visited, .wpjm-dashboard .job-manager-message a:hover, .wpjm-dashboard .job-manager-message a:active, .wpjm-dashboard .job-manager-message a:focus {
+    color: var(--cl-light);
+}
+
+.wpjm-dashboard .job-manager-message a:link, .wpjm-dashboard .job-manager-message a:visited {
+    text-decoration: underline;
+}
+
+.wpjm-dashboard .job-manager-message {
+    margin-bottom: var(--sp-medium);
+    padding: var(--sp-small) var(--sp-medium);
+    background: var(--cl-dark);
+    color: var(--cl-light);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .search-wrapper {
+    display: flex;
+    flex-grow: 2;
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .search-block .main-input svg {
+    width: 20px;
+    margin-right: var(--sp-small);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .search-block .main-input input[type="text"]::placeholder {
+    color: var(--cl-dark);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .search-block .main-input input[type="text"] {
+    width: 100%;
+    border: none;
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .search-block .main-input {
+    display: flex;
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .search-block {
+    flex-grow: 2;
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .submit-btn {
+    padding-right: var(--sp-medium);
+    border-right: solid 1px var(--cl-dark);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .wpbdp-listings-sort-options label {
+    padding-left: 0;
+    font-weight: var(--fw-normal);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .wpbdp-listings-sort-options select {
+    padding-left: var(--sp-small);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box .wpbdp-listings-sort-options {
+    padding-left: var(--sp-medium);
+    display: flex;
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-main-box {
+    display: flex;
+    width: 100%;
+    background-color: var(--cl-light);
+    align-items: center;
+    padding: 0 var(--sp-medium);
+    margin-bottom: var(--sp-xlarge);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a:hover .excerpt-content {
+    opacity: var(--op-light);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a .excerpt-content .listing-meta .wpbdp-field-value:not(:last-child) {
+    margin-bottom: var(--sp-small);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a .excerpt-content .listing-meta {
+    min-width: 300px;
+    margin-right: var(--sp-small);
+    background-color: var(--cl-light);
+    padding: var(--sp-medium);
+    font-size: var(--fs-body);
+    font-weight: var(--fw-semibold);
+    color: var(--cl-dark);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a .excerpt-content .listing-title h3 {
+    font-size: var(--fs-body);
+    font-weight: var(--fw-thin);
+    color: var(--cl-dark);
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a .excerpt-content .listing-title {
+    background-color: var(--cl-light);
+    padding: var(--sp-medium);
+    flex-grow: 1;
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a .excerpt-content {
+    display: flex;
+}
+
+.business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt {
+    padding: 0;
+    margin-bottom: var(--sp-medium);
+}
+
+.business-directory.wpbdp-view-main #container {
+    background-color: var(--cl-lightblue);
+    background-image: url(../../images/edpsy-swirls-28.svg);
+    background-size: 400px;
+    background-position: right -2px;
+    background-repeat: no-repeat;
+}
+
+.business-directory.wpbdp-view-main .listing-actions, .business-directory.wpbdp-view-main .wpbdp-categories {
+    display: none;
+}
+
+.business-directory.single-wpbdp_listing article .edp-thesis-meta p {
+    margin-bottom: 0;
+}
+
+.business-directory.single-wpbdp_listing article .wpbdp-further-reading-block .value p a {
+    width: fit-content;
+}
+
+.business-directory.single-wpbdp_listing article .wpbdp-further-reading-block .value p {
+    display: flex;
+    flex-direction: column;
+}
+
+.business-directory.single-wpbdp_listing article .wpbdp-further-reading-block {
+    margin-top: var(--sp-medium);
+}
+
+.business-directory.single-wpbdp_listing article {
+    margin-bottom: var(--sp-xxlarge);
+}
+
+.business-directory.single-wpbdp_listing .listing-actions, .business-directory.single-wpbdp_listing .wpbdp-categories {
+    display: none;
+}
+
+.edp-jobs.single-job_listing article.type-job_listing header .entry-title, .edp-jobs.single-job_listing article.type-job_listing header .tribe-events-single-event-title, .edp-jobs.single-job_listing article.type-tribe_events header .entry-title, .edp-jobs.single-job_listing article.type-tribe_events header .tribe-events-single-event-title, .edp-jobs.single-job_listing article.type-wpbdp_listing header .entry-title, .edp-jobs.single-job_listing article.type-wpbdp_listing header .tribe-events-single-event-title, .single-tribe_events article.type-job_listing header .entry-title, .single-tribe_events article.type-job_listing header .tribe-events-single-event-title, .single-tribe_events article.type-tribe_events header .entry-title, .single-tribe_events article.type-tribe_events header .tribe-events-single-event-title, .single-tribe_events article.type-wpbdp_listing header .entry-title, .single-tribe_events article.type-wpbdp_listing header .tribe-events-single-event-title, .single-wpbdp_listing article.type-job_listing header .entry-title, .single-wpbdp_listing article.type-job_listing header .tribe-events-single-event-title, .single-wpbdp_listing article.type-tribe_events header .entry-title, .single-wpbdp_listing article.type-tribe_events header .tribe-events-single-event-title, .single-wpbdp_listing article.type-wpbdp_listing header .entry-title, .single-wpbdp_listing article.type-wpbdp_listing header .tribe-events-single-event-title {
+    margin-bottom: var(--sp-small);
+}
+
+.edp-jobs.single-job_listing article.type-job_listing header .edp-wpbdp-name, .edp-jobs.single-job_listing article.type-tribe_events header .edp-wpbdp-name, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-wpbdp-name, .single-tribe_events article.type-job_listing header .edp-wpbdp-name, .single-tribe_events article.type-tribe_events header .edp-wpbdp-name, .single-tribe_events article.type-wpbdp_listing header .edp-wpbdp-name, .single-wpbdp_listing article.type-job_listing header .edp-wpbdp-name, .single-wpbdp_listing article.type-tribe_events header .edp-wpbdp-name, .single-wpbdp_listing article.type-wpbdp_listing header .edp-wpbdp-name {
+    font-size: var(--fs-title-large);
+    font-weight: var(--fw-semibold);
+    line-height: var(--lh-title-large);
+}
+
+.edp-jobs.single-job_listing article.type-job_listing header .company, .edp-jobs.single-job_listing article.type-job_listing header .edp-event-date-time, .edp-jobs.single-job_listing article.type-job_listing header .edp-event-cost, .edp-jobs.single-job_listing article.type-job_listing header .edp-event-location, .edp-jobs.single-job_listing article.type-job_listing header .edp-event-on-demand, .edp-jobs.single-job_listing article.type-job_listing header .wpbdp-year-inst-block, .edp-jobs.single-job_listing article.type-tribe_events header .company, .edp-jobs.single-job_listing article.type-tribe_events header .edp-event-date-time, .edp-jobs.single-job_listing article.type-tribe_events header .edp-event-cost, .edp-jobs.single-job_listing article.type-tribe_events header .edp-event-location, .edp-jobs.single-job_listing article.type-tribe_events header .edp-event-on-demand, .edp-jobs.single-job_listing article.type-tribe_events header .wpbdp-year-inst-block, .edp-jobs.single-job_listing article.type-wpbdp_listing header .company, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-event-date-time, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-event-cost, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-event-location, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-event-on-demand, .edp-jobs.single-job_listing article.type-wpbdp_listing header .wpbdp-year-inst-block, .single-tribe_events article.type-job_listing header .company, .single-tribe_events article.type-job_listing header .edp-event-date-time, .single-tribe_events article.type-job_listing header .edp-event-cost, .single-tribe_events article.type-job_listing header .edp-event-location, .single-tribe_events article.type-job_listing header .edp-event-on-demand, .single-tribe_events article.type-job_listing header .wpbdp-year-inst-block, .single-tribe_events article.type-tribe_events header .company, .single-tribe_events article.type-tribe_events header .edp-event-date-time, .single-tribe_events article.type-tribe_events header .edp-event-cost, .single-tribe_events article.type-tribe_events header .edp-event-location, .single-tribe_events article.type-tribe_events header .edp-event-on-demand, .single-tribe_events article.type-tribe_events header .wpbdp-year-inst-block, .single-tribe_events article.type-wpbdp_listing header .company, .single-tribe_events article.type-wpbdp_listing header .edp-event-date-time, .single-tribe_events article.type-wpbdp_listing header .edp-event-cost, .single-tribe_events article.type-wpbdp_listing header .edp-event-location, .single-tribe_events article.type-wpbdp_listing header .edp-event-on-demand, .single-tribe_events article.type-wpbdp_listing header .wpbdp-year-inst-block, .single-wpbdp_listing article.type-job_listing header .company, .single-wpbdp_listing article.type-job_listing header .edp-event-date-time, .single-wpbdp_listing article.type-job_listing header .edp-event-cost, .single-wpbdp_listing article.type-job_listing header .edp-event-location, .single-wpbdp_listing article.type-job_listing header .edp-event-on-demand, .single-wpbdp_listing article.type-job_listing header .wpbdp-year-inst-block, .single-wpbdp_listing article.type-tribe_events header .company, .single-wpbdp_listing article.type-tribe_events header .edp-event-date-time, .single-wpbdp_listing article.type-tribe_events header .edp-event-cost, .single-wpbdp_listing article.type-tribe_events header .edp-event-location, .single-wpbdp_listing article.type-tribe_events header .edp-event-on-demand, .single-wpbdp_listing article.type-tribe_events header .wpbdp-year-inst-block, .single-wpbdp_listing article.type-wpbdp_listing header .company, .single-wpbdp_listing article.type-wpbdp_listing header .edp-event-date-time, .single-wpbdp_listing article.type-wpbdp_listing header .edp-event-cost, .single-wpbdp_listing article.type-wpbdp_listing header .edp-event-location, .single-wpbdp_listing article.type-wpbdp_listing header .edp-event-on-demand, .single-wpbdp_listing article.type-wpbdp_listing header .wpbdp-year-inst-block {
+    font-size: var(--fs-title-medium);
+    font-weight: var(--fw-semibold);
+    line-height: var(--lh-title-large);
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .meta-slice .meta-img-l, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .meta-img-l, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .meta-img-l, .single-tribe_events article.type-job_listing .meta-slice .meta-img-l, .single-tribe_events article.type-tribe_events .meta-slice .meta-img-l, .single-tribe_events article.type-wpbdp_listing .meta-slice .meta-img-l, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-l, .single-wpbdp_listing article.type-tribe_events .meta-slice .meta-img-l, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .meta-img-l {
+    background-repeat: no-repeat;
+    background-position: 0 0;
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item .label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item .label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .field-label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .field-label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .field-label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .meta-item .label, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .meta-item .field-label, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .label, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .field-label, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .meta-item .label, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .meta-item .field-label, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .label, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .field-label, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .label, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .label, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .field-label, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item .label, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item .field-label, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .label, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .field-label, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item .label, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item .field-label, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .field-label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .field-label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label {
+    width: fit-content;
+    text-align: right;
+    padding-right: var(--sp-medium);
+    border-right: 1px solid var(--cl-dark);
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .value, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .value, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item .value, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .value, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item .value, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .value, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .value, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .value, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .value, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .meta-item .detail, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .meta-item .value, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .detail, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .value, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .meta-item .detail, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .meta-item .value, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .value, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .value, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .value, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .value, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item .detail, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item .value, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .detail, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item .value, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item .detail, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item .value, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item .value, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item .value, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value {
+    padding-left: var(--sp-medium);
+    padding-right: var(--sp-medium);
+    font-weight: var(--fw-normal);
+    padding-bottom: var(--sp-small);
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .meta-item, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .meta-item, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .meta-item, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .meta-item, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .meta-item, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .meta-item, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .meta-item, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .meta-item, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display {
+    display: flex;
+    padding: 0 var(--sp-medium);
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .meta-slice .job-listing-meta, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .edp-thesis-meta, .edp-jobs.single-job_listing article.type-job_listing .meta-slice .event-listing-meta, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .job-listing-meta, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .edp-thesis-meta, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .event-listing-meta, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .job-listing-meta, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .event-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta, .single-tribe_events article.type-tribe_events .meta-slice .job-listing-meta, .single-tribe_events article.type-tribe_events .meta-slice .edp-thesis-meta, .single-tribe_events article.type-tribe_events .meta-slice .event-listing-meta, .single-tribe_events article.type-wpbdp_listing .meta-slice .job-listing-meta, .single-tribe_events article.type-wpbdp_listing .meta-slice .edp-thesis-meta, .single-tribe_events article.type-wpbdp_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.type-tribe_events .meta-slice .job-listing-meta, .single-wpbdp_listing article.type-tribe_events .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.type-tribe_events .meta-slice .event-listing-meta, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .event-listing-meta {
+    margin: var(--sp-medium) 0;
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .meta-slice .meta-img-r, .edp-jobs.single-job_listing article.type-tribe_events .meta-slice .meta-img-r, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice .meta-img-r, .single-tribe_events article.type-job_listing .meta-slice .meta-img-r, .single-tribe_events article.type-tribe_events .meta-slice .meta-img-r, .single-tribe_events article.type-wpbdp_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.type-tribe_events .meta-slice .meta-img-r, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice .meta-img-r {
+    background-repeat: no-repeat;
+    background-position: 0 100%;
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .job-listing-logo img, .edp-jobs.single-job_listing article.type-tribe_events .job-listing-logo img, .edp-jobs.single-job_listing article.type-wpbdp_listing .job-listing-logo img, .single-tribe_events article.type-job_listing .job-listing-logo img, .single-tribe_events article.type-tribe_events .job-listing-logo img, .single-tribe_events article.type-wpbdp_listing .job-listing-logo img, .single-wpbdp_listing article.type-job_listing .job-listing-logo img, .single-wpbdp_listing article.type-tribe_events .job-listing-logo img, .single-wpbdp_listing article.type-wpbdp_listing .job-listing-logo img {
+    max-height: 150px;
+    max-width: 290px;
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .job-listing-logo, .edp-jobs.single-job_listing article.type-tribe_events .job-listing-logo, .edp-jobs.single-job_listing article.type-wpbdp_listing .job-listing-logo, .single-tribe_events article.type-job_listing .job-listing-logo, .single-tribe_events article.type-tribe_events .job-listing-logo, .single-tribe_events article.type-wpbdp_listing .job-listing-logo, .single-wpbdp_listing article.type-job_listing .job-listing-logo, .single-wpbdp_listing article.type-tribe_events .job-listing-logo, .single-wpbdp_listing article.type-wpbdp_listing .job-listing-logo {
+    margin-top: var(--sp-xxlarge);
+    margin-left: var(--sp-medium);
+}
+
+.edp-jobs.single-job_listing article.type-job_listing .meta-slice, .edp-jobs.single-job_listing article.type-wpbdp_listing .meta-slice, .single-tribe_events article.type-job_listing .meta-slice, .single-tribe_events article.type-wpbdp_listing .meta-slice, .single-wpbdp_listing article.type-job_listing .meta-slice, .single-wpbdp_listing article.type-wpbdp_listing .meta-slice {
+    margin: var(--sp-xxlarge) 0;
+}
+
+.edp-jobs.single-job_listing article.type-tribe_events .meta-slice, .single-tribe_events article.type-tribe_events .meta-slice, .single-wpbdp_listing article.type-tribe_events .meta-slice {
+    margin: var(--sp-xxxlarge) 0 var(--sp-medium) 0;
+}
+
+.edp-jobs.single-job_listing .wpjm-submit-block, .single-tribe_events .wpjm-submit-block, .single-wpbdp_listing .wpjm-submit-block {
+    margin: var(--sp-medium) 0;
+}
+
+.edp-jobs.single-job_listing .job-footer .footnote-asa, .single-tribe_events .job-footer .footnote-asa, .single-wpbdp_listing .job-footer .footnote-asa {
+    text-align: center;
+    margin: var(--sp-large) 0;
+}
+
+.edp-jobs.single-job_listing header .company {
+    color: var(--cl-jobs-primary);
+}
+
+.edp-jobs.single-job_listing article .meta-img-l {
+    background-image: url(../../images/edpsy-swirls-14.svg);
+}
+
+.edp-jobs.single-job_listing article .meta-img-r {
+    background-image: url(../../images/edpsy-swirls-13.svg);
+}
+
+.edp-jobs.single-job_listing article {
+    margin-bottom: 0;
+}
+
+.single-wpbdp_listing article.type-wpbdp_listing header .name-inst-year .wpbdp-year-inst-block {
+    font-weight: var(--fw-light);
+}
+
+.single-wpbdp_listing article.type-wpbdp_listing header .name-inst-year {
+    color: var(--cl-thesis-primary);
+}
+
+.single-wpbdp_listing article.type-wpbdp_listing .meta-img-l {
+    background-image: url(../../images/edpsy-swirls-23.svg);
+}
+
+.single-wpbdp_listing article.type-wpbdp_listing .meta-img-r {
+    background-image: url(../../images/edpsy-swirls-13.svg);
+}
+
+.single-wpbdp_listing article.type-wpbdp_listing {
+    margin-bottom: var(--sp-xxlarge);
+}
+
+.single-tribe_events .tribe-events-ajax-loading {
+    display: none;
+}
+
+.single-tribe_events header .edp-event-date-time, .single-tribe_events header .edp-event-cost, .single-tribe_events header .edp-event-on-demand {
+    color: var(--cl-purple);
+}
+
+.single-tribe_events .meta-img-l {
+    background-image: url(../../images/edpsy-swirls-17.svg);
+}
+
+.single-tribe_events .meta-img-r {
+    background-image: url(../../images/edpsy-swirls-15.svg);
+}
+
+.home #container.edp-fullwidth {
+    background-image: url(../../images/edpsy-swirls-21-90.svg);
+    background-color: var(--cl-dark);
+    background-position: calc(100% + 2px) top;
+    background-repeat: no-repeat;
+    background-size: 300px;
+    padding-top: 150px;
+}
+
+.home a:link, .home a:visited {
+    color: var(--cl-light);
+}
+
+.home .hero-post, .home .home-divider, .home .focus-on, .home .longer-reads {
+    margin-bottom: 100px;
+    border-radius: var(--rd-large);
+}
+
+.home .article-grid {
+    margin-bottom: var(--sp-home-gap);
+}
+
+.home section.hero-post a:hover h1, .home section.hero-post a:active h1 {
+    color: var(--cl-purple);
+}
+
+.home section.hero-post a:hover, .home section.hero-post a:active {
+    box-shadow: none;
+    opacity: var(--op-light);
+}
+
+.home section.hero-post h2 {
+    color: var(--cl-light);
+}
+
+.home section.hero-post .home-hero-item a .hero-text h1 {
+    font-size: var(--fs-title-large);
+    line-height: var(--lh-title-large);
+    font-weight: var(--fw-semibold);
+    margin-bottom: var(--sp-small);
+}
+
+.home section.hero-post .home-hero-item a .hero-text {
+    width: calc(50% - (var(--sp-medium))/2);
+}
+
+.home section.hero-post .home-hero-item a .hero-image {
+    width: calc(50% - (var(--sp-medium))/2);
+    aspect-ratio: var(--aspect-ratio-landscape);
+    border-radius: var(--rd-large);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.home section.hero-post .home-hero-item a {
+    display: flex;
+    flex-direction: row;
+    gap: var(--sp-home-gap);
+    color: var(--cl-dark);
+}
+
+.home section.hero-post {
+    margin-top: 0px !important;
+    margin-bottom: 90px !important;
+    background-color: var(--cl-light);
+}
+
+.home .home-see-all {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.home .article-grid .article-item {
+    background-color: var(--cl-dark-50);
+    border-radius: var(--rd-large);
+}
+
+.home .article-grid li.job_listing:active .home-article-image, .home .article-grid li.job_listing:hover .home-article-image, .home .article-grid .article-item:active .home-article-image, .home .article-grid .article-item:hover .home-article-image {
+    filter: brightness(75%);
+}
+
+.home .article-grid .article-item, .crp_related .article-grid .article-item {
+    width: calc(33.333% - (2*(var(--sp-home-gap)))/3);
+    margin-bottom: calc(var(--sp-xlarge) - var(--sp-home-gap));
+    ;
+}
+
+.home .article-grid a:hover h3, .home .article-grid a:active h3, .crp_related .article-grid a:hover h3, .crp_related .article-grid a:active h3 {
+    color: var(--cl-lightpurple-hover);
+}
+
+.home .article-grid a:hover .crp_title, .home .article-grid a:active .crp_title, .crp_related .article-grid a:hover .crp_title, .crp_related .article-grid a:active .crp_title {
+    color: var(--cl-lightpurple-hover);
+}
+
+.home .article-grid, .crp_related .article-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-home-gap);
+}
+
+.home .article-item h3, .home .article-item .crp_title, .home li.job_listing h3, .home li.job_listing .crp_title, .crp_related .article-item h3, .crp_related .article-item .crp_title, .crp_related li.job_listing h3, .crp_related li.job_listing .crp_title {
+    font-size: var(--fs-body);
+    line-height: var(--lh-body);
+    font-weight: var(--fw-semibold);
+}
+
+.crp_related .article-item a:hover .crp_title, .crp_related .article-item a:active .crp_title {
+    color: var(--cl-purple);
+}
+
+.crp_related .article-item .crp_title {
+    display: block;
+}
+
+section.hero-post h2, section.focus-on h2, section.longer-reads h2 {
+    margin-top: -60px;
+}
+
+section.hero-post, section.focus-on, section.longer-reads {
+    margin-bottom: 100px;
+}
+
+section.hero-post, section.focus-on, section.longer-reads, section.homepage-jobs-wrapper {
+    margin-top: 60px;
+}
+
+section.homepage-events-wrapper {
+    padding-top: 84px !important;
+}
+
+section.hero-post h2, section.focus-on h2, section.longer-reads h2, section.homepage-events-wrapper h2, section.homepage-jobs-wrapper h2 {
+    font-size: 60px;
+    margin-bottom: var(--sp-home-gap);
+    margin-left: -5px;
+}
+
+section.hero-post a:link, section.hero-post a:visited, section.focus-on a:link, section.focus-on a:visited, section.longer-reads a:link, section.longer-reads a:visited, section.homepage-events-wrapper a:link, section.homepage-events-wrapper a:visited, section.homepage-jobs-wrapper a:link, section.homepage-jobs-wrapper a:visited {
+    color: var(--cl-dark);
+}
+
+section.hero-post a:hover h3, section.hero-post a:active h3, section.focus-on a:hover h3, section.focus-on a:active h3, section.longer-reads a:hover h3, section.longer-reads a:active h3, section.homepage-events-wrapper a:hover h3, section.homepage-events-wrapper a:active h3, section.homepage-jobs-wrapper a:hover h3, section.homepage-jobs-wrapper a:active h3 {
+    color: var(--cl-purple);
+}
+
+section.hero-post a:hover .home-article-image, section.hero-post a:active .home-article-image, section.focus-on a:hover .home-article-image, section.focus-on a:active .home-article-image, section.longer-reads a:hover .home-article-image, section.longer-reads a:active .home-article-image, section.homepage-events-wrapper a:hover .home-article-image, section.homepage-events-wrapper a:active .home-article-image, section.homepage-jobs-wrapper a:hover .home-article-image, section.homepage-jobs-wrapper a:active .home-article-image {
+    filter: brightness(75%);
+}
+
+section.hero-post .focus-posts-grid, section.hero-post .longer-reads-grid, section.hero-post .jobs-homepage-grid, section.focus-on .focus-posts-grid, section.focus-on .longer-reads-grid, section.focus-on .jobs-homepage-grid, section.longer-reads .focus-posts-grid, section.longer-reads .longer-reads-grid, section.longer-reads .jobs-homepage-grid, section.homepage-events-wrapper .focus-posts-grid, section.homepage-events-wrapper .longer-reads-grid, section.homepage-events-wrapper .jobs-homepage-grid, section.homepage-jobs-wrapper .focus-posts-grid, section.homepage-jobs-wrapper .longer-reads-grid, section.homepage-jobs-wrapper .jobs-homepage-grid {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--sp-home-gap);
+}
+
+section.hero-post, section.focus-on, section.longer-reads, section.homepage-events-wrapper, section.homepage-jobs-wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+section.hero-post, section.focus-on, section.longer-reads, section.homepage-events-wrapper, section.homepage-jobs-wrapper {
+    padding: var(--sp-medium);
+}
+
+section.hero-post h2 a:link, section.hero-post h2 a:visited, section.focus-on h2 a:link, section.focus-on h2 a:visited, section.longer-reads h2 a:link, section.longer-reads h2 a:visited, section.homepage-events-wrapper h2 a:link, section.homepage-events-wrapper h2 a:visited {
+    color: var(--cl-light);
+}
+
+section.hero-post h2 a:hover, section.hero-post h2 a:active, section.focus-on h2 a:hover, section.focus-on h2 a:active, section.longer-reads h2 a:hover, section.longer-reads h2 a:active, section.homepage-events-wrapper h2 a:hover, section.homepage-events-wrapper h2 a:active {
+    color: var(--cl-light-75);
+}
+
+section.homepage-jobs-wrapper h2 a:link, section.homepage-jobs-wrapper h2 a:visited {
+    color: var(--cl-orange);
+}
+
+section.homepage-jobs-wrapper h2 a:hover, section.homepage-jobs-wrapper h2 a:active {
+    opacity: var(--op-light);
+}
+
+section.homepage-jobs-wrapper li.job_listing:active .home-article-image, section.homepage-jobs-wrapper li.job_listing:hover .home-article-image, section.homepage-jobs-wrapper .article-item:active .home-article-image, section.homepage-jobs-wrapper .article-item:hover .home-article-image {
+    filter: brightness(90%);
+}
+
+section.hero-post h2 {
+    color: var(--cl-light);
+}
+
+section.hero-post {
+    background-color: var(--cl-light);
+}
+
+section.longer-reads h2 {
+    color: var(--cl-light);
+}
+
+section.longer-reads {
+    background-color: var(--cl-light);
+}
+
+section.focus-on h2 {
+    color: var(--cl-light);
+}
+
+section.focus-on {
+    background-color: var(--cl-light);
+}
+
+section.homepage-jobs-wrapper .homepage-jobs h2 {
+    color: var(--cl-orange);
+    margin-bottom: var(--sp-large);
+}
+
+section.homepage-jobs-wrapper .homepage-jobs article.job_listing {
+    margin-bottom: 0;
+}
+
+section.homepage-jobs-wrapper .homepage-jobs .edp-jobs-promo--home {
+    height: 100%;
+}
+
+section.homepage-jobs-wrapper .homepage-jobs {
+    margin-top: var(--sp-medium);
+    width: 100%;
+}
+
+section.homepage-jobs-wrapper {
+    padding: var(--sp-medium);
+    background-color: var(--cl-light);
+}
+
+.focus-on.edp-bold-posts-4 .article-item, .jobs-homepage-grid.edp-bold-posts-4 .article-item {
+    width: calc(25% - (3*(var(--sp-home-gap)))/4);
+}
+
+.focus-on.edp-bold-posts-3 .article-item, .jobs-homepage-grid.edp-bold-posts-3 .article-item, .jobs-homepage-grid.edp-bold-posts-2 .article-item, .jobs-homepage-grid.edp-bold-posts-3 .article-item {
+    width: calc(33.333% - (2*(var(--sp-home-gap)))/3);
+}
+
+.focus-on.edp-bold-posts-2 .article-item, .longer-reads.edp-bold-posts-2 .article-item {
+    width: calc(50% - ((var(--sp-home-gap)))/2);
+}
+
+.homepage-events-wrapper .homepage-events h2 {
+    color: var(--cl-light);
+    margin-bottom: var(--sp-large);
+}
+
+.homepage-events-wrapper .homepage-events {
+    margin-bottom: 60px;
+}
+
+.homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper .edp-events-calendar-list__event-row .edp-event-title-and-meta .edp-events-calendar-list__event-header .edp-events-calendar-list__event-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper .edp-events-calendar-list__event-row .edp-event-title-and-meta .edp-events-calendar-list__event-header {
+    margin-right: 0;
+}
+
+.homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper .edp-events-calendar-list__event-row .edp-event-title-and-meta .edp-events-calendar-list__event-meta .epd-events-calendar-list__event-venue {
+    margin-bottom: 0;
+}
+
+.homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper .edp-events-calendar-list__event-row .edp-event-title-and-meta .edp-events-calendar-list__event-meta {
+    padding-top: 0;
+}
+
+.homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper .edp-events-calendar-list__event-row .edp-event-title-and-meta {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+}
+
+.homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper .edp-events-calendar-list__event-row {
+    width: calc(50% - ((var(--sp-home-gap)))/2);
+}
+
+.homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper {
+    display: flex;
+    width: 100%;
+    gap: var(--sp-home-gap);
+}
+
+.homepage-events-wrapper .edp-events-calendar-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-home-gap);
+}
+
+.homepage-events-wrapper {
+    background-color: var(--cl-dark);
+}
+
+.home-divider.home-divider--jobs-events {
+    margin-bottom: 100px;
+}
+
+.home-divider {
+    height: 75px;
+    width: 100%;
+    background-image: url(../../images/edpsy-swirls-21.svg);
+    background-size: cover;
+    background-position: center;
+}
+
+body.home .article-item .home-article-image, body.home .article-item .archive-article-img, body.home .article-item .crp_featured, body.home li.job_listing .home-article-image, body.home li.job_listing .archive-article-img, body.home li.job_listing .crp_featured, body.archive article.type-post.has-post-thumbnail .home-article-image, body.archive article.type-post.has-post-thumbnail .archive-article-img, body.archive article.type-post.has-post-thumbnail .crp_featured, body .crp_related .home-article-image, body .crp_related .archive-article-img, body .crp_related .crp_featured {
+    width: 100%;
+    aspect-ratio: 2 / 1;
+    overflow: hidden;
+    align-content: center;
+    justify-content: center;
+    margin-bottom: var(--sp-small);
+    border-radius: var(--rd-large);
+}
+
+body.home .article-item.job-summary .home-article-image .crp_job_logo, body.home .article-item .job-summary .home-article-image .crp_job_logo, body.home li.job_listing.job-summary .home-article-image .crp_job_logo, body.home li.job_listing .job-summary .home-article-image .crp_job_logo, body.archive article.type-post.has-post-thumbnail.job-summary .home-article-image .crp_job_logo, body.archive article.type-post.has-post-thumbnail .job-summary .home-article-image .crp_job_logo, body .crp_related.job-summary .home-article-image .crp_job_logo, body .crp_related .job-summary .home-article-image .crp_job_logo {
+    object-fit: contain;
+    width: 80%;
+    height: 80%;
+}
+
+body.home .article-item.job-summary .home-article-image, body.home .article-item .job-summary .home-article-image, body.home li.job_listing.job-summary .home-article-image, body.home li.job_listing .job-summary .home-article-image, body.archive article.type-post.has-post-thumbnail.job-summary .home-article-image, body.archive article.type-post.has-post-thumbnail .job-summary .home-article-image, body .crp_related.job-summary .home-article-image, body .crp_related .job-summary .home-article-image {
+    text-align: center;
+    border: solid 1px var(--cl-dark-50);
+    background-color: var(--cl-light);
+    border-radius: var(--rd-large);
+}
+
+body.home .article-item img.wp-post-image, body.home .article-item img.crp_thumb:not(.crp_job_logo), body.home li.job_listing img.wp-post-image, body.home li.job_listing img.crp_thumb:not(.crp_job_logo), body.archive article.type-post.has-post-thumbnail img.wp-post-image, body.archive article.type-post.has-post-thumbnail img.crp_thumb:not(.crp_job_logo), body .crp_related img.wp-post-image, body .crp_related img.crp_thumb:not(.crp_job_logo) {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+    border-radius: var(--rd-large);
+}
+
+body.home .article-item img.crp_thumb.crp_job_logo, body.home li.job_listing img.crp_thumb.crp_job_logo, body.archive article.type-post.has-post-thumbnail img.crp_thumb.crp_job_logo, body .crp_related img.crp_thumb.crp_job_logo {
+    margin-bottom: 0;
+}
+
+.entry-footer .crp_related .article-grid .article-item a:hover .home-article-image, .entry-footer .crp_related .article-grid .article-item a:hover .crp_thumbnail, .entry-footer .crp_related .article-grid .article-item a:active .home-article-image, .entry-footer .crp_related .article-grid .article-item a:active .crp_thumbnail {
+    filter: brightness(90%);
+}
+
+.entry-footer .crp_related .article-grid .article-item a:hover, .entry-footer .crp_related .article-grid .article-item a:active {
+    box-shadow: none;
+}
+
+.entry-footer .crp_related {
+    margin-left: var(--sp-medium);
+    margin-right: var(--sp-medium);
+}
+
+#signup-slice .signup-content .message h2 {
+    font-size: var(--fs-display-small);
+    line-height: var(--lh-display-small);
+    font-weight: var(--fw-semibold);
+    padding-bottom: var(--sp-small);
+}
+
+#signup-slice .signup-content .message p {
+    margin-bottom: var(--sp-small);
+}
+
+#signup-slice .signup-content .message {
+    width: 60%;
+    padding-right: var(--sp-large);
+}
+
+#signup-slice .signup-content {
+    background-color: var(--cl-light);
+    padding: var(--sp-large);
+    display: flex;
+    align-items: start;
+}
+
+#signup-slice {
+    background-color: var(--cl-light);
+    color: var(--cl-dark);
+    padding: var(--sp-xxxlarge) 0;
+    background-image: url('../../images/edpsy-swirls-05.svg');
+    background-size: cover;
+    background-position: center;
+}
+
+footer#footer .footer-container a:link, footer#footer .footer-container a:visited {
+    color: var(--cl-light);
+}
+
+footer#footer .footer-container a:hover, footer#footer .footer-container a:active {
+    opacity: var(--op-strong);
+}
+
+footer#footer .footer-container .footer-content p, footer#footer .footer-container .foot-legal p {
+    margin-bottom: 0;
+}
+
+footer#footer .footer-container .footer-content p.footer-social, footer#footer .footer-container .foot-legal p.footer-social {
+    margin-bottom: var(--sp-small);
+}
+
+footer#footer .footer-container .footer-content .footer-message, footer#footer .footer-container .foot-legal .footer-message {
+    flex-wrap: wrap;
+}
+
+footer#footer .footer-container .footer-content, footer#footer .footer-container .foot-legal {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    align-items: center;
+}
+
+footer#footer .footer-container .footer-social i {
+    font-size: var(--fs-title-small);
+    line-height: 20px;
+}
+
+footer#footer .footer-container .footer-social a {
+    display: flex;
+}
+
+footer#footer .footer-container .footer-social .footer-bluesky-svg {
+    display: flex;
+    height: 20px;
+    width: 23px;
+}
+
+footer#footer .footer-container .footer-social .footer-mail {
+    align-items: center;
+    gap: var(--sp-xsmall);
+}
+
+footer#footer .footer-container .footer-social, footer#footer .footer-container .footer-message {
+    color: var(--cl-light-50);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+footer#footer .footer-container .footer-social {
+    gap: var(--sp-small);
+}
+
+footer#footer .footer-container .footer-message a {
+    margin: 0 var(--sp-small);
+}
+
+footer#footer .footer-container .footer-ecologi {
+    max-height: 150px;
+}
+
+footer#footer .footer-container .foot-legal div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-xxsmall);
+    justify-content: center;
+}
+
+footer#footer .footer-container .foot-legal {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-xxsmall);
+    font-size: var(--fs-body-medium);
+}
+
+footer#footer .footer-container .footer-right img {
+    min-width: 150px;
+}
+
+footer#footer .footer-container .footer-right {
+    align-content: center;
+}
+
+footer#footer .footer-container.footer-container--two {
+    background-color: var(--cl-dark-plus);
+    margin-right: 0;
+    margin-left: 0;
+    padding: var(--sp-large) var(--sp-medium);
+    max-width: 100%;
+}
+
+footer#footer .footer-container {
+    max-width: 1248px;
+    display: flex;
+    gap: var(--sp-home-gap);
+    justify-content: space-between;
+    margin: 0 auto 0 auto;
+    padding: var(--sp-xlarge);
+}
+
+footer#footer .footer-logo {
+    width: 124px;
+    height: 116px;
+}
+
+footer#footer {
+    background-color: var(--cl-dark);
+    color: var(--cl-light);
+    padding: 0;
+}
+
+.skehead-headernav-shrink .promo-banner-block {
+    display: none;
+}
+
+.promo-banner-block {
+    padding: 20px;
+    color: var(--cl-light);
+    background: var(--cl-purple);
+}
+
+.cta-body-block {
+    padding: 20px;
+}
+
+.promo-banner-block img, .cta-body-block img {
+    max-height: 20px;
+    padding-right: 10px;
+}
+
+.cta-body-block p {
+    margin-bottom: 0;
+}
+
+.promo-banner-block a:link, .promo-banner-block a:visited {
+    color: var(--cl-light);
+    text-decoration: underline;
+}
+
+.promo-banner-block a:hover, .promo-banner-block a:focus {
+    color: var(--cl-light);
+    text-decoration: none;
+}
+
+.promo-banner-block-style--edpsybold-light a:link, .promo-banner-block-style--edpsybold-light a:visited, .promo-banner-block-style--edpsybold-light a:hover, .promo-banner-block-style--edpsybold-light a:active {
+    color: var(--cl-dark);
+}
+
+.promo-banner-block-style--edpsybold-light {
+    background: var(--cl-light);
+    color: var(--cl-dark);
+    border-bottom: solid 1px var(--cl-dark);
+}
+
+.promo-banner-block-style--edpsybold-dark {
+    background: var(--cl-dark);
+}
+
+.promo-banner-block-style--edpsybold-orange {
+    background: var(--cl-orange);
+}
+
+.promo-banner-block-style--edpsybold-blue-light {
+    background: var(--cl-lightblue);
+}
+
+.promo-banner-block-style--edpsybold-green {
+    background: var(--cl-green);
+}
+
+.promo-banner-block-style--edpsybold-yellow {
+    background: var(--cl-yellow);
+}
+
+.promo-banner-block-style--edpsybold-purple-dark {
+    background: var(--cl-purple);
+}
+
+.promo-banner-block-style--edpsybold-puple-medium {
+    background: var(--cl-medpurple);
+}
+
+.promo-banner-block-style--edpsybold-puple-light {
+    background: var(--cl-lightpurple);
+}
+
+.promo-banner-block-style--green-bright {
+    background: #20b0bd;
+    background: -moz-linear-gradient(-45deg, #2b7583 0%, #20b0bd 100%);
+    background: -webkit-linear-gradient(-45deg, #2b7583 0%, #20b0bd 100%);
+}
+
+.promo-banner-block-style--green-dark {
+    background: #009736;
+    background: -moz-linear-gradient(-45deg, #009736 0%, #097831 100%);
+    background: -webkit-linear-gradient(-45deg, #009736 0%, #097831 100%);
+}
+
+.promo-banner-block-style--black {
+    background: #000;
+    background: -moz-linear-gradient(-45deg, #000 0%, #3c3c3c 100%);
+    background: -webkit-linear-gradient(-45deg, #000 0%, #3c3c3c 100%);
+}
+
+.promo-banner-block-style--festival-1 {
+    background: #0c1729 url("../images/banner-festival-2.jpg") right no-repeat;
+    background-size: 1000px;
+}
+
+.promo-banner-block-style--green-light {
+    background: var(--cl-green);
+    background: -moz-linear-gradient(-45deg, var(--cl-green) 0%, #5f8929 100%);
+    background: -webkit-linear-gradient(-45deg, var(--cl-green) 0%, #5f8929 100%);
+    background: linear-gradient(135deg, var(--cl-green) 0%, #5f8929 100%);
+}
+
+.promo-banner-block-style--festival-25 p a:link, .promo-banner-block-style--festival-25 p a:visited, .promo-banner-block-style--festival-25 p a:hover, .promo-banner-block-style--festival-25 p a:active {
+    color: var(--cl-medpurple);
+    font-weight: 400;
+    text-decoration: none;
+}
+
+.promo-banner-block-style--festival-25 p a:link, .promo-banner-block-style--festival-25 p a:visited {
+    text-decoration: none;
+}
+
+.promo-banner-block-style--festival-25 p a:hover, .promo-banner-block-style--festival-25 p a:active {
+    text-decoration: underline;
+}
+
+.promo-banner-block-style--festival-25 p {
+    color: var(--cl-dark);
+    background: rgba(255, 255, 255, 0.93);
+    padding: 5px 7px;
+    margin-left: -7px;
+}
+
+.promo-banner-block-style--festival-25 {
+    background: var(--cl-purple) url("../../images/banner-festival-25-2.jpg");
+    background-size: cover;
+}
+
+.promo-banner-block-style--festival-1 {
+    background: #0c1729 url("../images/banner-festival-2.jpg") right no-repeat;
+    background-size: 1000px;
+}
+
+.promo-banner-block-style--green-light {
+    background: $color-about;
+    background: -moz-linear-gradient(-45deg, $color-about 0%, #5f8929 100%);
+    background: -webkit-linear-gradient(-45deg, $color-about 0%, #5f8929 100%);
+}
+
+.promo-banner-block-style--dark {
+    background: #181c1d;
+    background: -moz-linear-gradient(-45deg, rgb(28, 28, 34) 0%, #555b5c 100%);
+    background: -webkit-linear-gradient(-45deg, rgb(28, 28, 34) 0%, #555b5c 100%);
+}
+
+.promo-banner-block a.cta-header-button {
+    border: 1px solid white;
+    padding: 0 12px;
+    display: inline-block;
+    margin-left: 10px;
+    font-weight: 400;
+    line-height: 3rem;
+    background-color: #fff;
+    border-width: 0;
+    outline: none;
+    border-radius: 2px;
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
+    transition: background-color .3s;
+}
+
+.promo-banner-block .promo-banner-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.promo-banner-block p {
+    margin-bottom: 0;
+    vertical-align: bottom;
+    font-size: 18px;
+    font-weight: 300;
+    line-height: 1.3rem;
+}
+
+.promo-banner-block .row-fluid {
+    margin-left: 0;
+}
+
+.promo-banner-block a.cta-header-button:hover, .promo-banner-block a.cta-header-button:focus {
+    box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.14), 0 1px 7px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -1px rgba(0, 0, 0, 0.2);
+}
+
+.promo-banner-block .row-fluid:before, .promo-banner-block .row-fluid:after {
+    display: none !important;
+}
+
+div.post#post-7821 .container.post-wrap .row-fluid, div.post#post-7817 .container.post-wrap .row-fluid, div.post#post-7819 .container.post-wrap .row-fluid, div.post#post-9346 .container.post-wrap .row-fluid {
+    background: white;
+}
+
+div.post#post-7817, div.post#post-7819, div.post#post-7821, div.post#post-9346 {
+    background-image: url("../images/reuk-background--3.png");
+    background-repeat: repeat-y;
+    background-size: contain;
+    background-position: right top;
+}
+
+.promo-banner-block-style--refugee-pale {
+    background: #b28bfc;
+    background: -moz-linear-gradient(-45deg, #b28bfc 0%, #ffbc8f 100%);
+    background: -webkit-linear-gradient(-45deg, #b28bfc 0%, #ffbc8f 100%);
+    background: linear-gradient(135deg, #b28bfc 0%, #ffbc8f 100%);
+    color: $color-copy;
+}
+
+.promo-banner-block-style--refugee {
+    background: #1D3A76;
+    background: -moz-linear-gradient(-45deg, #115599 0%, #2B65F5 100%);
+    background: -webkit-linear-gradient(-45deg, #115599 0%, #2B65F5 100%);
+    background: linear-gradient(135deg, #115599 0%, #2B65F5 100%);
+    //color: $color-copy;
+}
+
+.promo-banner-block.promo-banner-block-style--refugee-pale a:link, .promo-banner-block.promo-banner-block-style--refugee-pale a:visited, .promo-banner-block.promo-banner-block-style--refugee-pale a:hover, .promo-banner-block.promo-banner-block-style--refugee-pale a:active {
+    color: $color-copy;
+}
+
+.cta-body-block--refugee-pale {
+    color: #052d67;
+    margin-bottom: 20px;
+    border: rgba(187, 221, 255, 0.55) 1px solid;
+    box-shadow: inset 0 0 50px #fff,
+        
+        -2px 1px 65px rgba(178, 139, 252, 0.07) inset,
+        
+        50px 6px 100px rgba(255, 188, 143, 0.54),
+        
+        -30px 20px 78px rgba(178, 139, 252, 0.45),
+        
+        50px 5px 80px #fff;
+    margin-top: 30px;
+    margin-bottom: 30px;
+}
+
+.cta-body-block.cta-body-block--refugee-pale a:link, .cta-body-block.cta-body-block--refugee-pale a:visited, .cta-body-block.cta-body-block--refugee-pale a:hover, .cta-body-block.cta-body-block--refugee-pale a:active {
+    color: $color-link;
+}
+
+#content .cta-body-block.cta-body-block--refugee-pale a:hover, #content .cta-body-block.cta-body-block--refugee-pale a:active {
+    text-decoration: none;
+}
+
+.skepost:lang(ur) p, .skepost:lang(ur) li {
+    line-height: calc(var(--fs-body)*3);
+}
+
+.skepost:lang(ur) h2:lang(en) {
+    margin-bottom: 30px;
+}
+
+@media only screen and (max-width: 1000px) {
+    .option-col1 {
+        width: 100%;
+        border-right: none;
+        padding-right: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .option-col2 {
+        width: 100%;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .option-block-or {
+        float: none;
+        margin: 4rem auto 3rem auto;
+        text-align: center;
+        padding: 0 6px 3px 6px;
+        border-radius: 0;
+        border: none;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post h1.entry-title {
+        grid-column: 1 / span 12;
+        font-size: var(--fs-title-large);
+        line-height: var(--lh-title-large);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-image {
+        grid-column: 1 / span 8;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta {
+        grid-column: 9 / span 4;
+        margin-right: 0;
+        margin-left: -30px;
+        gap: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content h2, body.single-post #container article.type-post .entry-content h3, body.single-post #container article.type-post .entry-content h4, body.single-post #container article.type-post .entry-content h5, body.single-post #container article.type-post .entry-content h6, body.single-post #container article.type-post .entry-content p, body.single-post #container article.type-post .entry-content ul, body.single-post #container article.type-post .entry-content ol, body.single-post #container article.type-post .entry-content blockquote, body.single-post #container article.type-post .entry-content .content-body {
+        grid-column: 2 / span 10;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .blog-swirls-tr {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section .author-avatars .author-avatar img, body.single-post #container article.type-post .entry-content .entry-author--top .authors-section .author-avatars .author-avatar img.wp-post-image {
+        width: 70px;
+        height: 70px;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section .author-avatars .author-avatar {
+        max-width: 70px;
+        max-height: 70px;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section .author-avatars {
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section.author-count-2 .author-2 {
+        margin-left: -20px;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section.author-count-4 .author-avatars .author-4, body.single-post #container article.type-post .entry-content .entry-author--top .authors-section.author-count-4 .author-avatars .author-3 {
+        margin-top: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section.author-count-4 .author-avatars .author-3 {
+        margin-left: -25px;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section.author-count-4 .author-avatars {
+        margin: 0;
+        flex-wrap: nowrap;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section {
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+        padding-left: var(--sp-medium);
+        gap: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .author-deco {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top {
+        grid-row: 1;
+        grid-column: 1 / span 10;
+        margin-top: 0;
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .author-name a {
+        font-weight: var(--fw-medium);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .author-name br {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content .author-name {
+        font-size: var(--sp-body-small);
+        text-align: left;
+        width: 100%;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    body.single-post #container article.type-post .entry-content {
+        display: grid;
+        grid-auto-flow: row;
+        margin-top: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .article-grid .article-item {
+        width: calc(50% - ((var(--sp-home-gap))/2));
+        margin-bottom: calc(var(--sp-xlarge) - var(--sp-home-gap));
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .homepage-jobs-wrapper {
+        margin: 0 var(--sp-neg-medium);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .focus-posts-grid .article-item a .article-item--image .home-article-image, .home .focus-on.edp-bold-posts-4 .longer-reads-grid .article-item a .article-item--image .home-article-image, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a .article-item--image .home-article-image, .home .focus-on.edp-bold-posts-3 .focus-posts-grid .article-item a .article-item--image .home-article-image, .home .focus-on.edp-bold-posts-3 .longer-reads-grid .article-item a .article-item--image .home-article-image, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a .article-item--image .home-article-image, .home .focus-on.edp-bold-posts-2 .focus-posts-grid .article-item a .article-item--image .home-article-image, .home .focus-on.edp-bold-posts-2 .longer-reads-grid .article-item a .article-item--image .home-article-image, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a .article-item--image .home-article-image, .home .longer-reads .focus-posts-grid .article-item a .article-item--image .home-article-image, .home .longer-reads .longer-reads-grid .article-item a .article-item--image .home-article-image, .home .longer-reads .jobs-homepage-grid .article-item a .article-item--image .home-article-image, .home .homepage-jobs .focus-posts-grid .article-item a .article-item--image .home-article-image, .home .homepage-jobs .longer-reads-grid .article-item a .article-item--image .home-article-image, .home .homepage-jobs .jobs-homepage-grid .article-item a .article-item--image .home-article-image {
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .focus-posts-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-4 .longer-reads-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-3 .focus-posts-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-3 .longer-reads-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-2 .focus-posts-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-2 .longer-reads-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a .article-item--image, .home .longer-reads .focus-posts-grid .article-item a .article-item--image, .home .longer-reads .longer-reads-grid .article-item a .article-item--image, .home .longer-reads .jobs-homepage-grid .article-item a .article-item--image, .home .homepage-jobs .focus-posts-grid .article-item a .article-item--image, .home .homepage-jobs .longer-reads-grid .article-item a .article-item--image, .home .homepage-jobs .jobs-homepage-grid .article-item a .article-item--image {
+        width: 30%;
+        display: flex;
+        align-items: center;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .focus-posts-grid .article-item a h3, .home .focus-on.edp-bold-posts-4 .longer-reads-grid .article-item a h3, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a h3, .home .focus-on.edp-bold-posts-3 .focus-posts-grid .article-item a h3, .home .focus-on.edp-bold-posts-3 .longer-reads-grid .article-item a h3, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a h3, .home .focus-on.edp-bold-posts-2 .focus-posts-grid .article-item a h3, .home .focus-on.edp-bold-posts-2 .longer-reads-grid .article-item a h3, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a h3, .home .longer-reads .focus-posts-grid .article-item a h3, .home .longer-reads .longer-reads-grid .article-item a h3, .home .longer-reads .jobs-homepage-grid .article-item a h3, .home .homepage-jobs .focus-posts-grid .article-item a h3, .home .homepage-jobs .longer-reads-grid .article-item a h3, .home .homepage-jobs .jobs-homepage-grid .article-item a h3 {
+        width: 70%;
+        padding-left: var(--sp-medium);
+        padding-top: var(--sp-small);
+        font-weight: normal;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .focus-posts-grid .article-item a:hover, .home .focus-on.edp-bold-posts-4 .focus-posts-grid .article-item a:active, .home .focus-on.edp-bold-posts-4 .longer-reads-grid .article-item a:hover, .home .focus-on.edp-bold-posts-4 .longer-reads-grid .article-item a:active, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a:hover, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a:active, .home .focus-on.edp-bold-posts-3 .focus-posts-grid .article-item a:hover, .home .focus-on.edp-bold-posts-3 .focus-posts-grid .article-item a:active, .home .focus-on.edp-bold-posts-3 .longer-reads-grid .article-item a:hover, .home .focus-on.edp-bold-posts-3 .longer-reads-grid .article-item a:active, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a:hover, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a:active, .home .focus-on.edp-bold-posts-2 .focus-posts-grid .article-item a:hover, .home .focus-on.edp-bold-posts-2 .focus-posts-grid .article-item a:active, .home .focus-on.edp-bold-posts-2 .longer-reads-grid .article-item a:hover, .home .focus-on.edp-bold-posts-2 .longer-reads-grid .article-item a:active, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a:hover, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a:active, .home .longer-reads .focus-posts-grid .article-item a:hover, .home .longer-reads .focus-posts-grid .article-item a:active, .home .longer-reads .longer-reads-grid .article-item a:hover, .home .longer-reads .longer-reads-grid .article-item a:active, .home .longer-reads .jobs-homepage-grid .article-item a:hover, .home .longer-reads .jobs-homepage-grid .article-item a:active, .home .homepage-jobs .focus-posts-grid .article-item a:hover, .home .homepage-jobs .focus-posts-grid .article-item a:active, .home .homepage-jobs .longer-reads-grid .article-item a:hover, .home .homepage-jobs .longer-reads-grid .article-item a:active, .home .homepage-jobs .jobs-homepage-grid .article-item a:hover, .home .homepage-jobs .jobs-homepage-grid .article-item a:active {
+        box-shadow: none;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .focus-posts-grid .article-item a, .home .focus-on.edp-bold-posts-4 .longer-reads-grid .article-item a, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a, .home .focus-on.edp-bold-posts-3 .focus-posts-grid .article-item a, .home .focus-on.edp-bold-posts-3 .longer-reads-grid .article-item a, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a, .home .focus-on.edp-bold-posts-2 .focus-posts-grid .article-item a, .home .focus-on.edp-bold-posts-2 .longer-reads-grid .article-item a, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a, .home .longer-reads .focus-posts-grid .article-item a, .home .longer-reads .longer-reads-grid .article-item a, .home .longer-reads .jobs-homepage-grid .article-item a, .home .homepage-jobs .focus-posts-grid .article-item a, .home .homepage-jobs .longer-reads-grid .article-item a, .home .homepage-jobs .jobs-homepage-grid .article-item a {
+        display: flex;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .focus-posts-grid .article-item, .home .focus-on.edp-bold-posts-4 .longer-reads-grid .article-item, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item, .home .focus-on.edp-bold-posts-3 .focus-posts-grid .article-item, .home .focus-on.edp-bold-posts-3 .longer-reads-grid .article-item, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item, .home .focus-on.edp-bold-posts-2 .focus-posts-grid .article-item, .home .focus-on.edp-bold-posts-2 .longer-reads-grid .article-item, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item, .home .longer-reads .focus-posts-grid .article-item, .home .longer-reads .longer-reads-grid .article-item, .home .longer-reads .jobs-homepage-grid .article-item, .home .homepage-jobs .focus-posts-grid .article-item, .home .homepage-jobs .longer-reads-grid .article-item, .home .homepage-jobs .jobs-homepage-grid .article-item {
+        width: 100%;
+        margin-bottom: 0;
+        max-width: 700px;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .focus-posts-grid, .home .focus-on.edp-bold-posts-4 .longer-reads-grid, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid, .home .focus-on.edp-bold-posts-3 .focus-posts-grid, .home .focus-on.edp-bold-posts-3 .longer-reads-grid, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid, .home .focus-on.edp-bold-posts-2 .focus-posts-grid, .home .focus-on.edp-bold-posts-2 .longer-reads-grid, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid, .home .longer-reads .focus-posts-grid, .home .longer-reads .longer-reads-grid, .home .longer-reads .jobs-homepage-grid, .home .homepage-jobs .focus-posts-grid, .home .homepage-jobs .longer-reads-grid, .home .homepage-jobs .jobs-homepage-grid {
+        padding-top: var(--sp-xsmall);
+        flex-wrap: wrap;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .home-article-image .promo-text, .home .focus-on.edp-bold-posts-4 .home-article-image .promo-subtitle, .home .focus-on.edp-bold-posts-3 .home-article-image .promo-text, .home .focus-on.edp-bold-posts-3 .home-article-image .promo-subtitle, .home .focus-on.edp-bold-posts-2 .home-article-image .promo-text, .home .focus-on.edp-bold-posts-2 .home-article-image .promo-subtitle, .home .longer-reads .home-article-image .promo-text, .home .longer-reads .home-article-image .promo-subtitle, .home .homepage-jobs .home-article-image .promo-text, .home .homepage-jobs .home-article-image .promo-subtitle {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home .home-article-image .promo-text .promo-title, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home .home-article-image .promo-text .promo-title, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home .home-article-image .promo-text .promo-title, .home .longer-reads .page-promo .edp-jobs-promo--home .home-article-image .promo-text .promo-title, .home .homepage-jobs .page-promo .edp-jobs-promo--home .home-article-image .promo-text .promo-title {
+        color: var(--cl-orange);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home .home-article-image .promo-text, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home .home-article-image .promo-text, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home .home-article-image .promo-text, .home .longer-reads .page-promo .edp-jobs-promo--home .home-article-image .promo-text, .home .homepage-jobs .page-promo .edp-jobs-promo--home .home-article-image .promo-text {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home .home-article-image, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home .home-article-image, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home .home-article-image, .home .longer-reads .page-promo .edp-jobs-promo--home .home-article-image, .home .homepage-jobs .page-promo .edp-jobs-promo--home .home-article-image {
+        display: flex;
+        flex-direction: row;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home:link h3, .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home:visited h3, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home:link h3, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home:visited h3, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home:link h3, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home:visited h3, .home .longer-reads .page-promo .edp-jobs-promo--home:link h3, .home .longer-reads .page-promo .edp-jobs-promo--home:visited h3, .home .homepage-jobs .page-promo .edp-jobs-promo--home:link h3, .home .homepage-jobs .page-promo .edp-jobs-promo--home:visited h3 {
+        color: var(--cl-orange);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home:hover h3, .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home:hover .promo-subtitle, .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home:active h3, .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home:active .promo-subtitle, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home:hover h3, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home:hover .promo-subtitle, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home:active h3, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home:active .promo-subtitle, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home:hover h3, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home:hover .promo-subtitle, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home:active h3, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home:active .promo-subtitle, .home .longer-reads .page-promo .edp-jobs-promo--home:hover h3, .home .longer-reads .page-promo .edp-jobs-promo--home:hover .promo-subtitle, .home .longer-reads .page-promo .edp-jobs-promo--home:active h3, .home .longer-reads .page-promo .edp-jobs-promo--home:active .promo-subtitle, .home .homepage-jobs .page-promo .edp-jobs-promo--home:hover h3, .home .homepage-jobs .page-promo .edp-jobs-promo--home:hover .promo-subtitle, .home .homepage-jobs .page-promo .edp-jobs-promo--home:active h3, .home .homepage-jobs .page-promo .edp-jobs-promo--home:active .promo-subtitle {
+        color: var(--cl-purple);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home h3 .promo-subtitle, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home h3 .promo-subtitle, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home h3 .promo-subtitle, .home .longer-reads .page-promo .edp-jobs-promo--home h3 .promo-subtitle, .home .homepage-jobs .page-promo .edp-jobs-promo--home h3 .promo-subtitle {
+        margin-left: 0;
+        padding-left: 0;
+        text-align: left;
+        color: var(--cl-dark);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home i, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home i, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home i, .home .longer-reads .page-promo .edp-jobs-promo--home i, .home .homepage-jobs .page-promo .edp-jobs-promo--home i {
+        color: var(--cl-orange);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home h3 .promo-twolines, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home h3 .promo-twolines, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home h3 .promo-twolines, .home .longer-reads .page-promo .edp-jobs-promo--home h3 .promo-twolines, .home .homepage-jobs .page-promo .edp-jobs-promo--home h3 .promo-twolines {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home h3, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home h3, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home h3, .home .longer-reads .page-promo .edp-jobs-promo--home h3, .home .homepage-jobs .page-promo .edp-jobs-promo--home h3 {
+        display: block;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .home .focus-on.edp-bold-posts-4 .page-promo .edp-jobs-promo--home, .home .focus-on.edp-bold-posts-3 .page-promo .edp-jobs-promo--home, .home .focus-on.edp-bold-posts-2 .page-promo .edp-jobs-promo--home, .home .longer-reads .page-promo .edp-jobs-promo--home, .home .homepage-jobs .page-promo .edp-jobs-promo--home {
+        flex-direction: row;
+        padding: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .single-post .crp_related .article-grid .article-item {
+        width: calc(50% - ((var(--sp-home-gap))/2));
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page>*, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page .entry-content {
+        grid-column: 2 / span 10;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .single-tribe_events article.tribe-events-single>*, .single-tribe_events article.tribe-events-single .job_description, .single-tribe_events article.type-job_listing>*, .single-tribe_events article.type-job_listing .job_description, .single-tribe_events article.wpbdp_listing>*, .single-tribe_events article.wpbdp_listing .job_description, .single-job-listing article.tribe-events-single>*, .single-job-listing article.tribe-events-single .job_description, .single-job-listing article.type-job_listing>*, .single-job-listing article.type-job_listing .job_description, .single-job-listing article.wpbdp_listing>*, .single-job-listing article.wpbdp_listing .job_description, .single-wpbdp_listing article.tribe-events-single>*, .single-wpbdp_listing article.tribe-events-single .job_description, .single-wpbdp_listing article.type-job_listing>*, .single-wpbdp_listing article.type-job_listing .job_description, .single-wpbdp_listing article.wpbdp_listing>*, .single-wpbdp_listing article.wpbdp_listing .job_description, .job_listing_preview article.tribe-events-single>*, .job_listing_preview article.tribe-events-single .job_description, .job_listing_preview article.type-job_listing>*, .job_listing_preview article.type-job_listing .job_description, .job_listing_preview article.wpbdp_listing>*, .job_listing_preview article.wpbdp_listing .job_description {
+        grid-column: 2 / span 10;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .meta-img-l, .single-tribe_events article.type-job_listing .meta-slice .meta-img-l, .single-tribe_events article.wpbdp_listing .meta-slice .meta-img-l, .single-job-listing article.tribe-events-single .meta-slice .meta-img-l, .single-job-listing article.type-job_listing .meta-slice .meta-img-l, .single-job-listing article.wpbdp_listing .meta-slice .meta-img-l, .single-wpbdp_listing article.tribe-events-single .meta-slice .meta-img-l, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-l, .single-wpbdp_listing article.wpbdp_listing .meta-slice .meta-img-l, .job_listing_preview article.tribe-events-single .meta-slice .meta-img-l, .job_listing_preview article.type-job_listing .meta-slice .meta-img-l, .job_listing_preview article.wpbdp_listing .meta-slice .meta-img-l {
+        grid-column: 1 / span 2;
+        margin-left: var(--sp-neg-medium);
+        margin-right: var(--sp-neg-xxlarge);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .detail, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .value, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .field-label, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .detail, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .value, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .field-label, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .detail, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .value, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .field-label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .detail, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .value, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .field-label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .detail, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .value, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .field-label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .detail, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .value, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .detail, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .value, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .detail, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .value, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .detail, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .value, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .field-label, .single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .detail, .single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .value, .single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .field-label, .single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .detail, .single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .value, .single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .field-label, .single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .detail, .single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .value, .single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .field-label, .single-job-listing article.type-job_listing .meta-slice .job-listing-meta .detail, .single-job-listing article.type-job_listing .meta-slice .job-listing-meta .value, .single-job-listing article.type-job_listing .meta-slice .job-listing-meta .field-label, .single-job-listing article.type-job_listing .meta-slice .event-listing-meta .detail, .single-job-listing article.type-job_listing .meta-slice .event-listing-meta .value, .single-job-listing article.type-job_listing .meta-slice .event-listing-meta .field-label, .single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .detail, .single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .value, .single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .field-label, .single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .detail, .single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .value, .single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .field-label, .single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .detail, .single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .value, .single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .field-label, .single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .detail, .single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .value, .single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .value, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .value, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .value, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .field-label, .job_listing_preview article.tribe-events-single .meta-slice .job-listing-meta .detail, .job_listing_preview article.tribe-events-single .meta-slice .job-listing-meta .value, .job_listing_preview article.tribe-events-single .meta-slice .job-listing-meta .field-label, .job_listing_preview article.tribe-events-single .meta-slice .event-listing-meta .detail, .job_listing_preview article.tribe-events-single .meta-slice .event-listing-meta .value, .job_listing_preview article.tribe-events-single .meta-slice .event-listing-meta .field-label, .job_listing_preview article.tribe-events-single .meta-slice .edp-thesis-meta .detail, .job_listing_preview article.tribe-events-single .meta-slice .edp-thesis-meta .value, .job_listing_preview article.tribe-events-single .meta-slice .edp-thesis-meta .field-label, .job_listing_preview article.type-job_listing .meta-slice .job-listing-meta .detail, .job_listing_preview article.type-job_listing .meta-slice .job-listing-meta .value, .job_listing_preview article.type-job_listing .meta-slice .job-listing-meta .field-label, .job_listing_preview article.type-job_listing .meta-slice .event-listing-meta .detail, .job_listing_preview article.type-job_listing .meta-slice .event-listing-meta .value, .job_listing_preview article.type-job_listing .meta-slice .event-listing-meta .field-label, .job_listing_preview article.type-job_listing .meta-slice .edp-thesis-meta .detail, .job_listing_preview article.type-job_listing .meta-slice .edp-thesis-meta .value, .job_listing_preview article.type-job_listing .meta-slice .edp-thesis-meta .field-label, .job_listing_preview article.wpbdp_listing .meta-slice .job-listing-meta .detail, .job_listing_preview article.wpbdp_listing .meta-slice .job-listing-meta .value, .job_listing_preview article.wpbdp_listing .meta-slice .job-listing-meta .field-label, .job_listing_preview article.wpbdp_listing .meta-slice .event-listing-meta .detail, .job_listing_preview article.wpbdp_listing .meta-slice .event-listing-meta .value, .job_listing_preview article.wpbdp_listing .meta-slice .event-listing-meta .field-label, .job_listing_preview article.wpbdp_listing .meta-slice .edp-thesis-meta .detail, .job_listing_preview article.wpbdp_listing .meta-slice .edp-thesis-meta .value, .job_listing_preview article.wpbdp_listing .meta-slice .edp-thesis-meta .field-label {
+        background-color: var(--cl-light-75);
+        z-index: 4;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta, .single-job-listing article.tribe-events-single .meta-slice .job-listing-meta, .single-job-listing article.tribe-events-single .meta-slice .event-listing-meta, .single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta, .single-job-listing article.type-job_listing .meta-slice .job-listing-meta, .single-job-listing article.type-job_listing .meta-slice .event-listing-meta, .single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta, .single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta, .single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta, .single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta, .job_listing_preview article.tribe-events-single .meta-slice .job-listing-meta, .job_listing_preview article.tribe-events-single .meta-slice .event-listing-meta, .job_listing_preview article.tribe-events-single .meta-slice .edp-thesis-meta, .job_listing_preview article.type-job_listing .meta-slice .job-listing-meta, .job_listing_preview article.type-job_listing .meta-slice .event-listing-meta, .job_listing_preview article.type-job_listing .meta-slice .edp-thesis-meta, .job_listing_preview article.wpbdp_listing .meta-slice .job-listing-meta, .job_listing_preview article.wpbdp_listing .meta-slice .event-listing-meta, .job_listing_preview article.wpbdp_listing .meta-slice .edp-thesis-meta {
+        grid-column: 3 / span 8;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .meta-img-r, .single-tribe_events article.type-job_listing .meta-slice .meta-img-r, .single-tribe_events article.wpbdp_listing .meta-slice .meta-img-r, .single-job-listing article.tribe-events-single .meta-slice .meta-img-r, .single-job-listing article.type-job_listing .meta-slice .meta-img-r, .single-job-listing article.wpbdp_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.tribe-events-single .meta-slice .meta-img-r, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.wpbdp_listing .meta-slice .meta-img-r, .job_listing_preview article.tribe-events-single .meta-slice .meta-img-r, .job_listing_preview article.type-job_listing .meta-slice .meta-img-r, .job_listing_preview article.wpbdp_listing .meta-slice .meta-img-r {
+        grid-column: 11 / span 2;
+        margin-right: var(--sp-neg-medium);
+        margin-left: var(--sp-neg-xxxxlarge);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edp-jobs .page-promo .promo-text .promo-subtitle {
+        margin-left: 0;
+        margin-top: var(--sp-xsmall);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edp-jobs .page-promo .promo-text {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edp-jobs.job-listings-page .entry-content div.job_listings, .wpbdp-view-main :is(article.page)>*, .tribe-events-view--list .tribe-events-l-container>*, .tribe-events-view--list .tribe-events-header__top-bar, .tribe-events-view--list .event-disclaimer {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-cols {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .job-details-block-fieldset {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col2 {
+        width: 100%;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1 {
+        border-bottom: solid 4px var(--cl-jobs-primary);
+        border-right: none;
+        padding-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-block-or {
+        float: none;
+        margin-bottom: -20px;
+        margin-top: var(--sp-medium);
+        width: fit-content;
+        margin-right: auto;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form job_listing_stripe_checkout_form fieldset {
+        padding-left: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content .tribe-section-content-label, .edpsybold .category-jobs-admin fieldset label, .edpsybold .category-jobs-admin fieldset .tribe-section-content-label, .edpsybold .category-jobs-admin div.venue label, .edpsybold .category-jobs-admin div.venue .tribe-section-content-label, .edpsybold .category-jobs-admin div.organizer label, .edpsybold .category-jobs-admin div.organizer .tribe-section-content-label, .edpsybold .category-jobs-admin .tribe-section-content-row label, .edpsybold .category-jobs-admin .tribe-section-content-row .tribe-section-content-label, .edpsybold .category-jobs-admin div.events-community-post-title label, .edpsybold .category-jobs-admin div.events-community-post-title .tribe-section-content-label, .edpsybold .category-jobs-admin .events-community-post-content label, .edpsybold .category-jobs-admin .events-community-post-content .tribe-section-content-label, .edpsybold.tribe_community_edit fieldset label, .edpsybold.tribe_community_edit fieldset .tribe-section-content-label, .edpsybold.tribe_community_edit div.venue label, .edpsybold.tribe_community_edit div.venue .tribe-section-content-label, .edpsybold.tribe_community_edit div.organizer label, .edpsybold.tribe_community_edit div.organizer .tribe-section-content-label, .edpsybold.tribe_community_edit .tribe-section-content-row label, .edpsybold.tribe_community_edit .tribe-section-content-row .tribe-section-content-label, .edpsybold.tribe_community_edit div.events-community-post-title label, .edpsybold.tribe_community_edit div.events-community-post-title .tribe-section-content-label, .edpsybold.tribe_community_edit .events-community-post-content label, .edpsybold.tribe_community_edit .events-community-post-content .tribe-section-content-label {
+        width: 100%;
+        padding-left: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content, .edpsybold .category-jobs-admin fieldset, .edpsybold .category-jobs-admin div.venue, .edpsybold .category-jobs-admin div.organizer, .edpsybold .category-jobs-admin .tribe-section-content-row, .edpsybold .category-jobs-admin div.events-community-post-title, .edpsybold .category-jobs-admin .events-community-post-content, .edpsybold.tribe_community_edit fieldset, .edpsybold.tribe_community_edit div.venue, .edpsybold.tribe_community_edit div.organizer, .edpsybold.tribe_community_edit .tribe-section-content-row, .edpsybold.tribe_community_edit div.events-community-post-title, .edpsybold.tribe_community_edit .events-community-post-content {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        padding: 0 var(--sp-small) var(--sp-small) var(--sp-small);
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .fieldset-cap_declaration ul, .edpsybold .category-jobs-admin .fieldset-cap_declaration ul, .edpsybold.tribe_community_edit .fieldset-cap_declaration ul {
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .fieldset-cap_declaration, .edpsybold .category-jobs-admin .fieldset-cap_declaration, .edpsybold.tribe_community_edit .fieldset-cap_declaration {
+        margin-bottom: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.form-block-job-description#form-block-job-description {
+        padding: var(--sp-medium) var(--sp-small) var(--sp-small) var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold textarea#post_content, .edpsybold input#post_title {
+        width: 100%;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .fieldset-login_required {
+        border-right: none;
+        border-bottom: solid 4px var(--cl-jobs-primary);
+        margin-left: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .option-block-or {
+        float: none;
+        margin: 0 auto;
+        width: fit-content;
+        margin-bottom: -31px;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .edp-jobs-createaccount h3, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .edp-jobs-createaccount p {
+        padding-left: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin .edp-jobs-createaccount {
+        margin-left: 0;
+    }
+}
+
+@media only screen and (max-width: 1000px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.edpjobs-signin {
+        flex-direction: column;
+    }
+}
+
+@media screen and (min-width: 760px) {
+    .menu-item-has-children:last-of-type header[role="banner"] nav.top-nav-menu ul>li ul.sub-menu {
+        right: 0;
+    }
+}
+
+@media screen and (min-width: 760px) {
+    header[role="banner"] nav.top-nav-menu ul>li ul.sub-menu li a:hover, header[role="banner"] nav.top-nav-menu ul>li ul.sub-menu li a:active {
+        background-color: var(--cl-lightpurple-hover);
+    }
+}
+
+@media screen and (min-width: 760px) {
+    header[role="banner"] nav.top-nav-menu ul>li ul.sub-menu li a {
+        display: flex;
+        align-items: center;
+        width: auto;
+        min-width: 100%;
+        white-space: nowrap;
+        border: none;
+        height: 27px;
+    }
+}
+
+@media screen and (min-width: 760px) {
+    header[role="banner"] nav.top-nav-menu ul>li ul.sub-menu li {
+        width: 100%;
+    }
+}
+
+@media screen and (min-width: 760px) {
+    header[role="banner"] nav.top-nav-menu ul>li ul.sub-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        background-color: var(--cl-light);
+        z-index: 1000;
+        min-width: 100%;
+        width: max-content;
+        align-items: flex-start;
+        border: 1px solid var(--cl-dark);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    header[role="banner"] .menu-toggle {
+        display: block;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    header[role="banner"] nav.top-nav-menu ul li {
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    header[role="banner"] nav.top-nav-menu ul {
+        flex-direction: column;
+        align-items: flex-start;
+        width: 100%;
+        display: none;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    header[role="banner"] nav.top-nav-menu.open>ul>li a, header[role="banner"] nav.top-nav-menu.open>ul>li .submenu-wrapper a, header[role="banner"] nav.top-nav-menu.open>ul>.open ul>li a, header[role="banner"] nav.top-nav-menu.open>ul>.open ul>li .submenu-wrapper a {
+        width: 100%;
+        padding: var(--sp-small) var(--sp-small) var(--sp-small) var(--sp-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    header[role="banner"] nav.top-nav-menu.open>ul>li.menu-item-object-page, header[role="banner"] nav.top-nav-menu.open>ul>li .menu-item-object-page, header[role="banner"] nav.top-nav-menu.open>ul>.open ul>li.menu-item-object-page, header[role="banner"] nav.top-nav-menu.open>ul>.open ul>li .menu-item-object-page {
+        display: flex;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    header[role="banner"] nav.top-nav-menu.open>ul, header[role="banner"] nav.top-nav-menu.open>ul>.open ul {
+        display: flex;
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    header[role="banner"] nav.top-nav-menu {
+        grid-column: 1 / span 12;
+        margin-right: -24px;
+        margin-left: -24px;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    #signup-slice .signup-content .message {
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    #signup-slice .signup-content form br {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    #signup-slice .signup-content form {
+        width: 100%;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    #signup-slice .signup-content {
+        flex-wrap: wrap;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta, body.single-post #container article.type-post .author-image-header-block .entry-image {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta .entry-date-readtime {
+        display: flex;
+        gap: var(--sp-large);
+        font-weight: var(--fw-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta .tags--header .post-tag {
+        font-weight: var(--fw-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta .tags--header .post-tag--more {
+        font-weight: var(--fw-light);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta .tags--header {
+        padding-right: 110px;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta .entry-meta--share-button button {
+        font-size: var(--fs-small);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta .entry-meta--share-button {
+        width: 100%;
+        display: flex;
+        justify-content: end;
+        margin-top: -60px;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .author-image-header-block .entry-meta {
+        margin: 0;
+        padding-left: 0;
+        padding-top: var(--sp-small);
+        gap: var(--sp-small);
+        padding-bottom: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    body.single-post #container article.type-post .blog-header-block {
+        padding-bottom: var(--sp-large);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .meta-img-l, .single-tribe_events article.type-job_listing .meta-slice .meta-img-l, .single-tribe_events article.wpbdp_listing .meta-slice .meta-img-l, .single-job-listing article.tribe-events-single .meta-slice .meta-img-l, .single-job-listing article.type-job_listing .meta-slice .meta-img-l, .single-job-listing article.wpbdp_listing .meta-slice .meta-img-l, .single-wpbdp_listing article.tribe-events-single .meta-slice .meta-img-l, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-l, .single-wpbdp_listing article.wpbdp_listing .meta-slice .meta-img-l, .job_listing_preview article.tribe-events-single .meta-slice .meta-img-l, .job_listing_preview article.type-job_listing .meta-slice .meta-img-l, .job_listing_preview article.wpbdp_listing .meta-slice .meta-img-l {
+        grid-column: -1 / span 1;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta, .single-job-listing article.tribe-events-single .meta-slice .job-listing-meta, .single-job-listing article.tribe-events-single .meta-slice .event-listing-meta, .single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta, .single-job-listing article.type-job_listing .meta-slice .job-listing-meta, .single-job-listing article.type-job_listing .meta-slice .event-listing-meta, .single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta, .single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta, .single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta, .single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta, .job_listing_preview article.tribe-events-single .meta-slice .job-listing-meta, .job_listing_preview article.tribe-events-single .meta-slice .event-listing-meta, .job_listing_preview article.tribe-events-single .meta-slice .edp-thesis-meta, .job_listing_preview article.type-job_listing .meta-slice .job-listing-meta, .job_listing_preview article.type-job_listing .meta-slice .event-listing-meta, .job_listing_preview article.type-job_listing .meta-slice .edp-thesis-meta, .job_listing_preview article.wpbdp_listing .meta-slice .job-listing-meta, .job_listing_preview article.wpbdp_listing .meta-slice .event-listing-meta, .job_listing_preview article.wpbdp_listing .meta-slice .edp-thesis-meta {
+        grid-column: 1 / span 12;
+        padding-left: var(--sp-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .meta-img-r, .single-tribe_events article.type-job_listing .meta-slice .meta-img-r, .single-tribe_events article.wpbdp_listing .meta-slice .meta-img-r, .single-job-listing article.tribe-events-single .meta-slice .meta-img-r, .single-job-listing article.type-job_listing .meta-slice .meta-img-r, .single-job-listing article.wpbdp_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.tribe-events-single .meta-slice .meta-img-r, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.wpbdp_listing .meta-slice .meta-img-r, .job_listing_preview article.tribe-events-single .meta-slice .meta-img-r, .job_listing_preview article.type-job_listing .meta-slice .meta-img-r, .job_listing_preview article.wpbdp_listing .meta-slice .meta-img-r {
+        grid-column: 13 / span 1;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home.top-menu-open header[role="banner"] a.header-logo-wrapper .header-logo {
+        width: 48px;
+        margin: var(--sp-small) 0;
+        padding: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home.top-menu-open header[role="banner"] a.header-logo-wrapper {
+        padding: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home section.hero-post .home-hero-item a .hero-excerpt p {
+        margin-bottom: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home section.hero-post .home-hero-item a {
+        flex-direction: column;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home section.hero-post h2, .home section.focus-on h2, .home section.longer-reads h2, .home section.homepage-events-wrapper h2, .home section.homepage-jobs-wrapper h2 {
+        font-size: 50px;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home section.hero-post h2, .home section.focus-on h2, .home section.longer-reads h2 {
+        margin-top: -56px;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home .homepage-jobs .jobs-homepage-grid .page-promo .edp-jobs-promo--home .home-article-image i {
+        margin-left: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home .homepage-jobs .jobs-homepage-grid .page-promo .edp-jobs-promo--home .home-article-image .promo-title {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home .homepage-jobs .jobs-homepage-grid .page-promo .edp-jobs-promo--home h3 .promo-twolines {
+        display: inline;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home .homepage-jobs .jobs-homepage-grid .page-promo .edp-jobs-promo--home h3 .promo-oneline {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home .homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper .edp-events-calendar-list__event-row a {
+        padding-bottom: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home .homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper .edp-events-calendar-list__event-row {
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home .homepage-events-wrapper .edp-events-calendar-list .edp-events-calendar-list__event-row-wrapper {
+        flex-wrap: wrap;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .home .homepage-events-wrapper .edp-events-calendar-list {
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-header h3.edp-events-calendar-list__event-title {
+        font-size: var(--fs-body);
+        font-weight: var(--fw-semibold);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-header {
+        margin-right: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-meta .epd-events-calendar-list__event-venue {
+        margin-bottom: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-meta .tribe-events-calendar-list__event-cost {
+        margin-top: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-event-title-and-meta .edp-events-calendar-list__event-meta {
+        padding-top: 0;
+        display: flex;
+        gap: var(--sp-home-gap);
+        font-weight: var(--fw-extralight);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-event-title-and-meta {
+        flex-direction: column;
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .add-job article.category-jobs-admin>* {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-events-pg-template, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .entry-content, .edpsybold .category-jobs-admin .tribe-events-pg-template, .edpsybold .category-jobs-admin .entry-content, .edpsybold.tribe_community_edit .tribe-events-pg-template, .edpsybold.tribe_community_edit .entry-content {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-events-community-details, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block, .edpsybold .category-jobs-admin .tribe-events-community-details, .edpsybold .category-jobs-admin .tribe-section-content, .edpsybold .category-jobs-admin .form-block, .edpsybold.tribe_community_edit .tribe-events-community-details, .edpsybold.tribe_community_edit .tribe-section-content, .edpsybold.tribe_community_edit .form-block {
+        padding: var(--sp-small) var(--sp-small) var(--sp-medium) var(--sp-small);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-events-community-details#event_captcha, .edpsybold .category-jobs-admin .tribe-events-community-details#event_captcha, .edpsybold.tribe_community_edit .tribe-events-community-details#event_captcha {
+        padding-left: var(--sp-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-events-community-details, .edpsybold .category-jobs-admin .tribe-events-community-details, .edpsybold.tribe_community_edit .tribe-events-community-details {
+        padding-bottom: var(--sp-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title .tribe-section-content-label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content label, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content .tribe-section-content-label, .edpsybold .category-jobs-admin fieldset label, .edpsybold .category-jobs-admin fieldset .tribe-section-content-label, .edpsybold .category-jobs-admin div.venue label, .edpsybold .category-jobs-admin div.venue .tribe-section-content-label, .edpsybold .category-jobs-admin div.organizer label, .edpsybold .category-jobs-admin div.organizer .tribe-section-content-label, .edpsybold .category-jobs-admin .tribe-section-content-row label, .edpsybold .category-jobs-admin .tribe-section-content-row .tribe-section-content-label, .edpsybold .category-jobs-admin div.events-community-post-title label, .edpsybold .category-jobs-admin div.events-community-post-title .tribe-section-content-label, .edpsybold .category-jobs-admin .events-community-post-content label, .edpsybold .category-jobs-admin .events-community-post-content .tribe-section-content-label, .edpsybold.tribe_community_edit fieldset label, .edpsybold.tribe_community_edit fieldset .tribe-section-content-label, .edpsybold.tribe_community_edit div.venue label, .edpsybold.tribe_community_edit div.venue .tribe-section-content-label, .edpsybold.tribe_community_edit div.organizer label, .edpsybold.tribe_community_edit div.organizer .tribe-section-content-label, .edpsybold.tribe_community_edit .tribe-section-content-row label, .edpsybold.tribe_community_edit .tribe-section-content-row .tribe-section-content-label, .edpsybold.tribe_community_edit div.events-community-post-title label, .edpsybold.tribe_community_edit div.events-community-post-title .tribe-section-content-label, .edpsybold.tribe_community_edit .events-community-post-content label, .edpsybold.tribe_community_edit .events-community-post-content .tribe-section-content-label {
+        width: 100%;
+        padding-left: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth fieldset, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.venue, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.organizer, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content-row, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth div.events-community-post-title, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .events-community-post-content, .edpsybold .category-jobs-admin fieldset, .edpsybold .category-jobs-admin div.venue, .edpsybold .category-jobs-admin div.organizer, .edpsybold .category-jobs-admin .tribe-section-content-row, .edpsybold .category-jobs-admin div.events-community-post-title, .edpsybold .category-jobs-admin .events-community-post-content, .edpsybold.tribe_community_edit fieldset, .edpsybold.tribe_community_edit div.venue, .edpsybold.tribe_community_edit div.organizer, .edpsybold.tribe_community_edit .tribe-section-content-row, .edpsybold.tribe_community_edit div.events-community-post-title, .edpsybold.tribe_community_edit .events-community-post-content {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        padding: 0 var(--sp-small) var(--sp-small) var(--sp-small);
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth h2:not(#signup-slice h2, h2.my-events), .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-header h3, .edpsybold .category-jobs-admin h2:not(#signup-slice h2, h2.my-events), .edpsybold .category-jobs-admin .tribe-section-header h3, .edpsybold.tribe_community_edit h2:not(#signup-slice h2, h2.my-events), .edpsybold.tribe_community_edit .tribe-section-header h3 {
+        font-size: var(--fs-title-large);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .start-end-values, .edpsybold .category-jobs-admin .start-end-values, .edpsybold.tribe_community_edit .start-end-values {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        width: 70%;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold.add-job ul.progressbar {
+        margin-left: 0 !important;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold.edp-jobs.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing-logo {
+        grid-column: 1 / span 3;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold.edp-jobs.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing--details-meta .job-listing-details .job-title h2 {
+        font-size: var(--fs-body);
+        line-height: var(--lh-body);
+        font-weight: var(--fw-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold.edp-jobs.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing--details-meta .job-listing-details {
+        padding: var(--sp-small) var(--sp-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold.edp-jobs.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing--details-meta .job-listing-meta {
+        font-size: var(--fs-body-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .edpsybold.edp-jobs.edp-jobs.job-listings-page .entry-content ul.job_listings li a .job-listing--details-meta {
+        display: flex;
+        flex-direction: column;
+        border-left: 3px solid var(--cl-jobs-primary);
+        grid-column: 4 / span 8;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    footer#footer .footer-container .footer-logo {
+        width: 124px;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    footer#footer .footer-container .footer-right {
+        max-height: 80px;
+        max-width: 175px;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    footer#footer .footer-container.footer-container--two {
+        margin-top: var(--sp-medium);
+    }
+}
+
+@media screen and (max-width: 800px) {
+    footer#footer .footer-container {
+        flex-direction: column;
+        align-items: center;
+        gap: var(--sp-xlarge);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .single-post .crp_related .article-grid .article-item a figure, .single-post .crp_related .article-grid .article-item a .home-article-image {
+        width: 30%;
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .single-post .crp_related .article-grid .article-item a .crp_title {
+        width: 70%;
+        padding-bottom: 0;
+        padding-top: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .single-post .crp_related .article-grid .article-item a {
+        display: flex;
+        gap: var(--sp-home-gap);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .single-post .crp_related .article-grid .article-item {
+        width: 100%;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home .article-grid .article-item a .article-item--image .home-article-image, .home .focus-posts-grid .article-item a .article-item--image .home-article-image, .home .jobs-homepage-grid .article-item a .article-item--image .home-article-image {
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home .article-grid .article-item a .article-item--image, .home .focus-posts-grid .article-item a .article-item--image, .home .jobs-homepage-grid .article-item a .article-item--image {
+        width: 40%;
+        display: flex;
+        align-items: center;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home .article-grid .article-item a h3, .home .focus-posts-grid .article-item a h3, .home .jobs-homepage-grid .article-item a h3 {
+        width: 60%;
+        padding-left: var(--sp-medium);
+        padding-top: var(--sp-small);
+        font-weight: normal;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home .article-grid .article-item a:hover, .home .article-grid .article-item a:active, .home .focus-posts-grid .article-item a:hover, .home .focus-posts-grid .article-item a:active, .home .jobs-homepage-grid .article-item a:hover, .home .jobs-homepage-grid .article-item a:active {
+        box-shadow: none;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home .article-grid .article-item a, .home .focus-posts-grid .article-item a, .home .jobs-homepage-grid .article-item a {
+        display: flex;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home .article-grid .article-item, .home .focus-posts-grid .article-item, .home .jobs-homepage-grid .article-item {
+        width: 100%;
+        margin-bottom: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home section.hero-post .focus-posts-grid .article-item a:hover, .home section.hero-post .focus-posts-grid .article-item a:active, .home section.hero-post .longer-reads-grid .article-item a:hover, .home section.hero-post .longer-reads-grid .article-item a:active, .home section.hero-post .jobs-homepage-grid .article-item a:hover, .home section.hero-post .jobs-homepage-grid .article-item a:active, .home section.focus-on .focus-posts-grid .article-item a:hover, .home section.focus-on .focus-posts-grid .article-item a:active, .home section.focus-on .longer-reads-grid .article-item a:hover, .home section.focus-on .longer-reads-grid .article-item a:active, .home section.focus-on .jobs-homepage-grid .article-item a:hover, .home section.focus-on .jobs-homepage-grid .article-item a:active, .home section.longer-reads .focus-posts-grid .article-item a:hover, .home section.longer-reads .focus-posts-grid .article-item a:active, .home section.longer-reads .longer-reads-grid .article-item a:hover, .home section.longer-reads .longer-reads-grid .article-item a:active, .home section.longer-reads .jobs-homepage-grid .article-item a:hover, .home section.longer-reads .jobs-homepage-grid .article-item a:active, .home section.homepage-events-wrapper .focus-posts-grid .article-item a:hover, .home section.homepage-events-wrapper .focus-posts-grid .article-item a:active, .home section.homepage-events-wrapper .longer-reads-grid .article-item a:hover, .home section.homepage-events-wrapper .longer-reads-grid .article-item a:active, .home section.homepage-events-wrapper .jobs-homepage-grid .article-item a:hover, .home section.homepage-events-wrapper .jobs-homepage-grid .article-item a:active, .home section.homepage-jobs-wrapper .focus-posts-grid .article-item a:hover, .home section.homepage-jobs-wrapper .focus-posts-grid .article-item a:active, .home section.homepage-jobs-wrapper .longer-reads-grid .article-item a:hover, .home section.homepage-jobs-wrapper .longer-reads-grid .article-item a:active, .home section.homepage-jobs-wrapper .jobs-homepage-grid .article-item a:hover, .home section.homepage-jobs-wrapper .jobs-homepage-grid .article-item a:active {
+        box-shadow: none;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home section.hero-post .focus-posts-grid .article-item, .home section.hero-post .longer-reads-grid .article-item, .home section.hero-post .jobs-homepage-grid .article-item, .home section.focus-on .focus-posts-grid .article-item, .home section.focus-on .longer-reads-grid .article-item, .home section.focus-on .jobs-homepage-grid .article-item, .home section.longer-reads .focus-posts-grid .article-item, .home section.longer-reads .longer-reads-grid .article-item, .home section.longer-reads .jobs-homepage-grid .article-item, .home section.homepage-events-wrapper .focus-posts-grid .article-item, .home section.homepage-events-wrapper .longer-reads-grid .article-item, .home section.homepage-events-wrapper .jobs-homepage-grid .article-item, .home section.homepage-jobs-wrapper .focus-posts-grid .article-item, .home section.homepage-jobs-wrapper .longer-reads-grid .article-item, .home section.homepage-jobs-wrapper .jobs-homepage-grid .article-item {
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .home section.hero-post .focus-posts-grid, .home section.hero-post .longer-reads-grid, .home section.hero-post .jobs-homepage-grid, .home section.focus-on .focus-posts-grid, .home section.focus-on .longer-reads-grid, .home section.focus-on .jobs-homepage-grid, .home section.longer-reads .focus-posts-grid, .home section.longer-reads .longer-reads-grid, .home section.longer-reads .jobs-homepage-grid, .home section.homepage-events-wrapper .focus-posts-grid, .home section.homepage-events-wrapper .longer-reads-grid, .home section.homepage-events-wrapper .jobs-homepage-grid, .home section.homepage-jobs-wrapper .focus-posts-grid, .home section.homepage-jobs-wrapper .longer-reads-grid, .home section.homepage-jobs-wrapper .jobs-homepage-grid {
+        flex-wrap: wrap;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .archive.category #content>article, .archive.category #content>article, .archive.tag #content>article, .archive.tag #content>article {
+        flex-basis: 100%;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .archive.author .promo-1, .archive.tag .promo-1, .archive .promo-1 {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .archive.author .promo-2, .archive.tag .promo-2, .archive .promo-2 {
+        display: block;
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .archive.author .page-promo a i, .archive.tag .page-promo a i, .archive .page-promo a i {
+        font-size: var(--fs-title-small);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .archive.author .page-promo a, .archive.tag .page-promo a, .archive .page-promo a {
+        padding: var(--sp-xsmall) var(--sp-small);
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .archive .page-promo {
+        margin-top: 0;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    body.single-post article.type-post h1.entry-title {
+        grid-column: 1 / span 12;
+        margin-bottom: var(--sp-large);
+        font-size: var(--fs-title-smallmedium);
+        line-height: var(--lh-title-smallmedium);
+        margin-top: var(--sp-large);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    body.single-post article.type-post .entry-content a {
+        word-break: break-word;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    body.single-post article.type-post .entry-footer .tag-links, body.single-post article.type-post .entry-footer .author-info, body.single-post article.type-post .entry-footer .crp_related {
+        grid-column: 1 / span 12;
+        margin-left: var(--sp-medium);
+        margin-right: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    body.single-post article.type-post .entry-footer .tag-links .tag-items {
+        margin-left: var(--sp-neg-xsmall);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    body.single-post article.type-post .entry-footer .tag-links {
+        flex-direction: row;
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    body.single-post article.type-post .entry-footer .author-info .author-avatar {
+        margin-left: 0 !important;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    body.single-post article.type-post .entry-footer .author-info {
+        display: flex;
+        flex-direction: column;
+        margin-top: 0;
+        margin-bottom: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    body.single-post article.type-post .entry-footer {
+        margin-top: var(--sp-small);
+        padding-top: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edp-jobs h1, .archive.post-type-archive-tribe_events h1 {
+        margin: var(--sp-large) 0 var(--sp-xlarge) 0;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .business-directory.wpbdp-view-main h1 {
+        margin: var(--sp-xxlarge) 0 var(--sp-xlarge) 0;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edp-jobs .page-promo, .archive.post-type-archive-tribe_events .page-promo, .business-directory.wpbdp-view-main .page-promo {
+        margin-bottom: var(--sp-large);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .job-listings-page article header, .business-directory article header, .archive main header.header, .tribe-events header.tribe-events-header, .add-job header.header {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .single-post h1, .single-tribe_events h1, .edp-jobs.single-job_listing article.type-job_listing h1 {
+        font-size: var(--fs-title-smallmedium);
+        line-height: var(--lh-title-smallmedium);
+        margin-top: var(--sp-large);
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .single-post .job-listing-logo, .single-tribe_events .job-listing-logo, .edp-jobs.single-job_listing article.type-job_listing .job-listing-logo {
+        margin-top: var(--sp-large);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edp-jobs.single-job_listing article.type-job_listing header .company, .edp-jobs.single-job_listing article.type-job_listing header .edp-event-date-time, .edp-jobs.single-job_listing article.type-job_listing header .edp-event-cost, .edp-jobs.single-job_listing article.type-job_listing header .edp-event-location, .edp-jobs.single-job_listing article.type-job_listing header .edp-event-on-demand, .edp-jobs.single-job_listing article.type-job_listing header .wpbdp-year-inst-block, .edp-jobs.single-job_listing article.type-tribe_events header .company, .edp-jobs.single-job_listing article.type-tribe_events header .edp-event-date-time, .edp-jobs.single-job_listing article.type-tribe_events header .edp-event-cost, .edp-jobs.single-job_listing article.type-tribe_events header .edp-event-location, .edp-jobs.single-job_listing article.type-tribe_events header .edp-event-on-demand, .edp-jobs.single-job_listing article.type-tribe_events header .wpbdp-year-inst-block, .edp-jobs.single-job_listing article.type-wpbdp_listing header .company, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-event-date-time, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-event-cost, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-event-location, .edp-jobs.single-job_listing article.type-wpbdp_listing header .edp-event-on-demand, .edp-jobs.single-job_listing article.type-wpbdp_listing header .wpbdp-year-inst-block, .single-tribe_events article.type-job_listing header .company, .single-tribe_events article.type-job_listing header .edp-event-date-time, .single-tribe_events article.type-job_listing header .edp-event-cost, .single-tribe_events article.type-job_listing header .edp-event-location, .single-tribe_events article.type-job_listing header .edp-event-on-demand, .single-tribe_events article.type-job_listing header .wpbdp-year-inst-block, .single-tribe_events article.type-tribe_events header .company, .single-tribe_events article.type-tribe_events header .edp-event-date-time, .single-tribe_events article.type-tribe_events header .edp-event-cost, .single-tribe_events article.type-tribe_events header .edp-event-location, .single-tribe_events article.type-tribe_events header .edp-event-on-demand, .single-tribe_events article.type-tribe_events header .wpbdp-year-inst-block, .single-tribe_events article.type-wpbdp_listing header .company, .single-tribe_events article.type-wpbdp_listing header .edp-event-date-time, .single-tribe_events article.type-wpbdp_listing header .edp-event-cost, .single-tribe_events article.type-wpbdp_listing header .edp-event-location, .single-tribe_events article.type-wpbdp_listing header .edp-event-on-demand, .single-tribe_events article.type-wpbdp_listing header .wpbdp-year-inst-block, .single-wpbdp_listing article.type-job_listing header .company, .single-wpbdp_listing article.type-job_listing header .edp-event-date-time, .single-wpbdp_listing article.type-job_listing header .edp-event-cost, .single-wpbdp_listing article.type-job_listing header .edp-event-location, .single-wpbdp_listing article.type-job_listing header .edp-event-on-demand, .single-wpbdp_listing article.type-job_listing header .wpbdp-year-inst-block, .single-wpbdp_listing article.type-tribe_events header .company, .single-wpbdp_listing article.type-tribe_events header .edp-event-date-time, .single-wpbdp_listing article.type-tribe_events header .edp-event-cost, .single-wpbdp_listing article.type-tribe_events header .edp-event-location, .single-wpbdp_listing article.type-tribe_events header .edp-event-on-demand, .single-wpbdp_listing article.type-tribe_events header .wpbdp-year-inst-block, .single-wpbdp_listing article.type-wpbdp_listing header .company, .single-wpbdp_listing article.type-wpbdp_listing header .edp-event-date-time, .single-wpbdp_listing article.type-wpbdp_listing header .edp-event-cost, .single-wpbdp_listing article.type-wpbdp_listing header .edp-event-location, .single-wpbdp_listing article.type-wpbdp_listing header .edp-event-on-demand, .single-wpbdp_listing article.type-wpbdp_listing header .wpbdp-year-inst-block {
+        font-size: var(--fs-title-small);
+        line-height: var(--lh-title-small);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edp-jobs.single-job_listing .grid12 .menu-toggle, .single-tribe_events .grid12 .menu-toggle, .single-wpbdp_listing .grid12 .menu-toggle {
+        grid-column: 11 / span 2;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edpsybold.edp-jobs.add-job h1.entry-title {
+        margin-bottom: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edpsybold.edp-jobs.add-job .page-promo a .promo-title, .edpsybold.edp-jobs.add-job .page-promo a i {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edpsybold.edp-jobs.add-job .page-promo a .promo-subtitle {
+        display: flex;
+        flex-wrap: wrap;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edpsybold.edp-jobs.add-job .page-promo a {
+        padding: 0;
+        border: none;
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .fieldset-logged_in .field.account-sign-in .signin-text {
+        padding: var(--sp-small) 0 0 0;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .fieldset-logged_in .field.account-sign-in {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .business-directory.wpbdp-view-main #container .wpbdp-main-box .wpbdp-listings-sort-options {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a .excerpt-content .listing-meta .secondary-meta {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a .excerpt-content .listing-meta {
+        margin-right: 0;
+        padding-bottom: 0;
+        min-width: 200px;
+    }
+}
+
+@media only screen and (max-width: 700px) {
+    .business-directory.wpbdp-view-main #container .wpbdp-listing-excerpt a .excerpt-content {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body #container .entry-content ul, body #container .job_description ul, body #container .tribe-events-content ul, body #container .edp-thesis-abstract ul, body #container .category-jobs-admin ul, body #container fieldset.fieldset-cap_declaration ul, body #container .events-promo ul, body #container .category-jobs-admin ul {
+        margin-left: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold #container.edp-fullwidth .category-jobs ul.fa-features {
+        margin: var(--sp-medium) var(--sp-small) 0 var(--sp-large);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .home .article-grid .article-item a h3 {
+        width: 70%;
+        padding-top: var(--sp-xsmall);
+        padding-bottom: var(--sp-xsmall);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .home .article-grid .article-item {
+        width: 100%;
+        margin-bottom: var(--sp-xsmall);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .home section.hero-post h2, .home section.focus-on h2, .home section.longer-reads h2, .home section.homepage-events-wrapper h2, .home section.homepage-jobs-wrapper h2 {
+        font-size: var(--fs-title-large);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .home section.hero-post h2, .home section.focus-on h2, .home section.longer-reads h2 {
+        margin-top: -51px;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .fullwidth {
+        width: 100%;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content h2, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content h3, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content h4, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content h5, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content h6, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content p, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content ul, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content ol, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content blockquote, .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page body.single-post article.type-post .entry-content .content-body {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page .is-stacked-on-mobile figure {
+        margin-top: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .page-template-default:not(.job-listings-page, .wpbdp-view-main) article.type-page {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .archive.author .archive.category-blog .grid12 .archive-meta, body.archive.author .grid12 .archive-meta {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body.single-post #container article.type-post .entry-content .content-body {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single header .job-listing-logo, .single-tribe_events article.type-job_listing header .job-listing-logo, .single-tribe_events article.wpbdp_listing header .job-listing-logo, .edp-jobs.single-job-listing article.tribe-events-single header .job-listing-logo, .edp-jobs.single-job-listing article.type-job_listing header .job-listing-logo, .edp-jobs.single-job-listing article.wpbdp_listing header .job-listing-logo, .single-wpbdp_listing article.tribe-events-single header .job-listing-logo, .single-wpbdp_listing article.type-job_listing header .job-listing-logo, .single-wpbdp_listing article.wpbdp_listing header .job-listing-logo {
+        margin-left: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single header, .single-tribe_events article.type-job_listing header, .single-tribe_events article.wpbdp_listing header, .edp-jobs.single-job-listing article.tribe-events-single header, .edp-jobs.single-job-listing article.type-job_listing header, .edp-jobs.single-job-listing article.wpbdp_listing header, .single-wpbdp_listing article.tribe-events-single header, .single-wpbdp_listing article.type-job_listing header, .single-wpbdp_listing article.wpbdp_listing header {
+        display: flex;
+        flex-wrap: wrap;
+        flex-direction: column;
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item .label, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item .field-label, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item .label, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item .field-label, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .label, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .field-label, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .field-label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .field-label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .label, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .label, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .label, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .field-label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .field-label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .field-label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .field-label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .field-label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .field-label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .field-label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .label, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .label, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .label, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .field-label, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .field-label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .label, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .field-label {
+        text-align: left;
+        border: none;
+        font-weight: var(--fw-normal);
+        background-color: var(--cl-straw-75);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined .spacer, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined .spacer {
+        display: none;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail .wpjmef-field-combined, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value .wpjmef-field-combined {
+        display: flex;
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item .value, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item .value, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .value, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .value, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item .value, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item .value, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item .value, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item .value, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item .value, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .detail, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display .value {
+        padding-left: 0;
+        padding-right: 0;
+        font-weight: var(--fw-extralight);
+        background-color: var(--cl-straw-75);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .meta-item, .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .meta-item, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .meta-item, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .meta-item, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .meta-item, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .meta-item, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .meta-item, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .meta-item, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .meta-item, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .meta-item, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .meta-item, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .meta-item, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .meta-item, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .meta-item, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .meta-item, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-field-display, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .meta-item, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .meta-item, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta .wpbdp-field-display, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .meta-item, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-field-display {
+        display: flex;
+        flex-direction: column;
+        padding-left: 0;
+        width: fit-content;
+        padding-right: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .job-listing-meta, .single-tribe_events article.tribe-events-single .meta-slice .event-listing-meta, .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta, .single-tribe_events article.type-job_listing .meta-slice .job-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .event-listing-meta, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta, .single-tribe_events article.wpbdp_listing .meta-slice .job-listing-meta, .single-tribe_events article.wpbdp_listing .meta-slice .event-listing-meta, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .job-listing-meta, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .event-listing-meta, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .job-listing-meta, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .event-listing-meta, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .job-listing-meta, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .event-listing-meta, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .job-listing-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .event-listing-meta, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .job-listing-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .event-listing-meta, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta {
+        grid-column: 1 / span 11;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p {
+        margin-left: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-metadata-block>.wpbdp-field-display .value>p::before {
+        content: '•';
+        margin-left: var(--sp-neg-small-plus);
+        margin-right: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a {
+        margin-left: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before, .single-tribe_events article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before, .single-tribe_events article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before, .single-wpbdp_listing article.tribe-events-single .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before, .single-wpbdp_listing article.type-job_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before, .single-wpbdp_listing article.wpbdp_listing .meta-slice .edp-thesis-meta .wpbdp-further-reading-block .wpbdp-field-display a::before {
+        content: '•';
+        margin-left: var(--sp-neg-small-plus);
+        margin-right: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice .meta-img-r, .single-tribe_events article.type-job_listing .meta-slice .meta-img-r, .single-tribe_events article.wpbdp_listing .meta-slice .meta-img-r, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice .meta-img-r, .edp-jobs.single-job-listing article.type-job_listing .meta-slice .meta-img-r, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.tribe-events-single .meta-slice .meta-img-r, .single-wpbdp_listing article.type-job_listing .meta-slice .meta-img-r, .single-wpbdp_listing article.wpbdp_listing .meta-slice .meta-img-r {
+        margin-right: var(--sp-neg-xxxxlarge);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events article.tribe-events-single .meta-slice, .single-tribe_events article.type-job_listing .meta-slice, .single-tribe_events article.wpbdp_listing .meta-slice, .edp-jobs.single-job-listing article.tribe-events-single .meta-slice, .edp-jobs.single-job-listing article.type-job_listing .meta-slice, .edp-jobs.single-job-listing article.wpbdp_listing .meta-slice, .single-wpbdp_listing article.tribe-events-single .meta-slice, .single-wpbdp_listing article.type-job_listing .meta-slice, .single-wpbdp_listing article.wpbdp_listing .meta-slice {
+        background-color: var(--cl-straw);
+        margin: var(--sp-xlarge) var(--sp-neg-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .page-promo a {
+        flex-direction: row;
+        justify-content: space-between;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .page-promo {
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edp-jobs h1, body:not(.home).archive h1 {
+        font-size: var(--fs-display-medium);
+        line-height: var(--lh-display-medium);
+        margin: var(--sp-large) 0 var(--sp-large) 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edp-jobs.add-job .fieldset-logged_in .field.account-sign-in {
+        margin-top: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edp-jobs.add-job .fieldset-logged_in {
+        margin-bottom: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .page-template-default:not(.job-listings-page) article.type-page .crp_related .wp-block-media-text__content, article.job_listing .crp_related .wp-block-media-text__content, article.tribe-events-single .crp_related .wp-block-media-text__content, body:not(.home) article.type-post .crp_related .wp-block-media-text__content, article.type-wpbdp_listing .crp_related .wp-block-media-text__content, .tribe-events-pg-template .crp_related .wp-block-media-text__content, .edp-jobs.add-job .crp_related .wp-block-media-text__content {
+        margin-top: var(--sp-medium);
+        padding: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body.single-post #container article.type-post .entry-content .entry-author--top .authors-section {
+        flex-direction: column-reverse;
+        align-items: flex-start;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body:not(.home).archive article.type-post {
+        margin-bottom: var(--sp-large);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body:not(.home).archive .promo-2 {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body:not(.home).archive #container .author-info .author-avatar img {
+        width: 100px;
+        height: 100px;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body:not(.home).archive #container .author-info .author-avatar {
+        margin-left: 0;
+        margin-bottom: var(--sp-small);
+        padding-left: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body:not(.home).archive #container .author-info .author-description {
+        padding-right: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    body:not(.home).archive #container .author-info {
+        grid-column: 1 / span 12;
+        display: flex !important;
+        flex-direction: column;
+        padding: 0 var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .tribe-common-l-container, .edpsybold.tribe_community_edit #container .tribe-common-l-container {
+        margin: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .tribe-events-c-top-bar.tribe-events-header__top-bar, .edpsybold.tribe_community_edit #container .tribe-events-c-top-bar.tribe-events-header__top-bar {
+        display: flex;
+        align-items: center;
+        margin-bottom: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-header, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-header {
+        margin-right: 0;
+        padding-bottom: var(--sp-xxsmall);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-daynum, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-daynum {
+        font-size: var(--fs-title-small);
+        padding: 0;
+        min-height: auto;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime {
+        flex-direction: row;
+        justify-content: start;
+        padding: var(--sp-small) var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag {
+        margin-right: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-weekday, .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-daynum, .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-month, .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-header h3, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-weekday, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-daynum, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-date-tag .edp-events-calendar-list__event-date-tag-datetime .edp-events-calendar-list__event-date-tag-month, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-header h3 {
+        font-size: var(--fs-body);
+        line-height: var(--lh-body);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-meta, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a .edp-events-calendar-list__event-meta {
+        padding-top: 0;
+        display: flex;
+        justify-content: space-between;
+        padding-bottom: var(--sp-small);
+        font-weight: var(--fw-extralight);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .post-type-archive-tribe_events #container .edp-events-calendar-list__event-row a, .edpsybold.tribe_community_edit #container .edp-events-calendar-list__event-row a {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .single-tribe_events .tribe-events-after-html .event-disclaimer {
+        margin: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-logo {
+        justify-content: center;
+        padding-top: var(--sp-medium);
+        padding-bottom: var(--sp-medium);
+        border-bottom: 3px solid var(--cl-orange);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-logo, .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing--details-meta, .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-details, .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-meta {
+        grid-column: 1 / span 12;
+        border-left: none;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-logo img.company_logo, .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-details img.company_logo, .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-meta img.company_logo {
+        max-height: 100px;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-logo, .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-details, .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings ul.job_listings li a .job-listing-meta {
+        padding-left: var(--sp-medium);
+        padding-right: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold.edp-jobs.job-listings-page .entry-content div.job_listings {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    #signup-slice .signup-content .message h2 {
+        font-size: var(--fs-title-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    #signup-slice .signup-content .message {
+        padding-right: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold input[type="text"], .edpsybold input[type="email"], .edpsybold input#create_account_email, .edpsybold input[type="password"], .edpsybold input#company_name, .edpsybold .fieldset-type-term-multiselect .field, .edpsybold .checkbox-pair {
+        width: 100%;
+        max-width: var(--tb-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold input[type="text"]#company_website, .edpsybold input[type="text"]#application {
+        width: 100%;
+        max-width: var(--tb-large);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.form-block-job-description#form-block-job-description fieldset {
+        padding: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block.form-block-job-description#form-block-job-description {
+        padding: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    &.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1 fieldset label, &.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col2 fieldset label {
+        font-size: var(--fs-body);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    &.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1 fieldset, &.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col2 fieldset {
+        padding-left: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    &.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1, &.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col2 {
+        padding-right: var(--sp-medium);
+        padding-left: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    &.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset div.field:not(.full-line-checkbox-field) {
+        width: 100%;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    &.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1 {
+        border-bottom: solid 4px var(--cl-jobs-primary);
+        border-right: none;
+        padding-bottom: 0;
+        padding-top: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .business-directory.wpbdp-view-main #container .wpbdp-main-box .search-wrapper .submit-btn {
+        border: none;
+        padding: 0 var(--sp-small);
+        display: flex;
+        align-items: center;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .business-directory.wpbdp-view-main #container .wpbdp-main-box .search-wrapper {
+        width: 100%;
+        padding-left: var(--sp-small);
+        border: none;
+        background-color: var(--cl-light);
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .business-directory.wpbdp-view-main #container .wpbdp-main-box .wpbdp-listings-sort-options {
+        background-color: var(--cl-light);
+        padding: var(--sp-xsmall) var(--sp-small);
+        flex-direction: row;
+        align-items: center;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .business-directory.wpbdp-view-main #container .wpbdp-main-box {
+        flex-direction: column;
+        padding: 0;
+        gap: var(--sp-medium);
+        background: none;
+        align-items: end;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .wp-singular.page-template.page-template-template-fullwidth-jobs .grid12>* {
+        grid-column: 1 / span 12;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .wp-singular.page-template.page-template-template-fullwidth-jobs #job-manager-job-dashboard .job-manager-jobs tr td.job_title {
+        flex-direction: column;
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .wp-singular.page-template.page-template-template-fullwidth-jobs #job-manager-job-dashboard .job-manager-jobs tr .job-dashboard-actions {
+        margin-left: 0 !important;
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .wp-singular.page-template.page-template-template-fullwidth-jobs #job-manager-job-dashboard .job-manager-jobs tr {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .home .focus-on.edp-bold-posts-4 .article-item a .article-item--image, .home .focus-on.edp-bold-posts-4 .longer-reads .longer-reads-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-4 .focus-on .focus-posts-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-3 .article-item a .article-item--image, .home .focus-on.edp-bold-posts-3 .longer-reads .longer-reads-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-3 .focus-on .focus-posts-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-2 .article-item a .article-item--image, .home .focus-on.edp-bold-posts-2 .longer-reads .longer-reads-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-2 .focus-on .focus-posts-grid .article-item a .article-item--image, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a .article-item--image, .home .longer-reads .article-item a .article-item--image, .home .longer-reads .longer-reads .longer-reads-grid .article-item a .article-item--image, .home .longer-reads .focus-on .focus-posts-grid .article-item a .article-item--image, .home .longer-reads .jobs-homepage-grid .article-item a .article-item--image, .home .homepage-jobs .article-item a .article-item--image, .home .homepage-jobs .longer-reads .longer-reads-grid .article-item a .article-item--image, .home .homepage-jobs .focus-on .focus-posts-grid .article-item a .article-item--image, .home .homepage-jobs .jobs-homepage-grid .article-item a .article-item--image, .home .article-grid .article-item a .article-item--image, .home .article-grid .longer-reads .longer-reads-grid .article-item a .article-item--image, .home .article-grid .focus-on .focus-posts-grid .article-item a .article-item--image, .home .article-grid .jobs-homepage-grid .article-item a .article-item--image {
+        width: 100%;
+        max-width: 320px;
+        padding-left: var(--sp-small);
+        padding-top: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .home .focus-on.edp-bold-posts-4 .article-item a h3, .home .focus-on.edp-bold-posts-4 .longer-reads .longer-reads-grid .article-item a h3, .home .focus-on.edp-bold-posts-4 .focus-on .focus-posts-grid .article-item a h3, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a h3, .home .focus-on.edp-bold-posts-3 .article-item a h3, .home .focus-on.edp-bold-posts-3 .longer-reads .longer-reads-grid .article-item a h3, .home .focus-on.edp-bold-posts-3 .focus-on .focus-posts-grid .article-item a h3, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a h3, .home .focus-on.edp-bold-posts-2 .article-item a h3, .home .focus-on.edp-bold-posts-2 .longer-reads .longer-reads-grid .article-item a h3, .home .focus-on.edp-bold-posts-2 .focus-on .focus-posts-grid .article-item a h3, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a h3, .home .longer-reads .article-item a h3, .home .longer-reads .longer-reads .longer-reads-grid .article-item a h3, .home .longer-reads .focus-on .focus-posts-grid .article-item a h3, .home .longer-reads .jobs-homepage-grid .article-item a h3, .home .homepage-jobs .article-item a h3, .home .homepage-jobs .longer-reads .longer-reads-grid .article-item a h3, .home .homepage-jobs .focus-on .focus-posts-grid .article-item a h3, .home .homepage-jobs .jobs-homepage-grid .article-item a h3, .home .article-grid .article-item a h3, .home .article-grid .longer-reads .longer-reads-grid .article-item a h3, .home .article-grid .focus-on .focus-posts-grid .article-item a h3, .home .article-grid .jobs-homepage-grid .article-item a h3 {
+        width: 100%;
+        padding-left: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .home .focus-on.edp-bold-posts-4 .article-item a, .home .focus-on.edp-bold-posts-4 .longer-reads .longer-reads-grid .article-item a, .home .focus-on.edp-bold-posts-4 .focus-on .focus-posts-grid .article-item a, .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a, .home .focus-on.edp-bold-posts-3 .article-item a, .home .focus-on.edp-bold-posts-3 .longer-reads .longer-reads-grid .article-item a, .home .focus-on.edp-bold-posts-3 .focus-on .focus-posts-grid .article-item a, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a, .home .focus-on.edp-bold-posts-2 .article-item a, .home .focus-on.edp-bold-posts-2 .longer-reads .longer-reads-grid .article-item a, .home .focus-on.edp-bold-posts-2 .focus-on .focus-posts-grid .article-item a, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a, .home .longer-reads .article-item a, .home .longer-reads .longer-reads .longer-reads-grid .article-item a, .home .longer-reads .focus-on .focus-posts-grid .article-item a, .home .longer-reads .jobs-homepage-grid .article-item a, .home .homepage-jobs .article-item a, .home .homepage-jobs .longer-reads .longer-reads-grid .article-item a, .home .homepage-jobs .focus-on .focus-posts-grid .article-item a, .home .homepage-jobs .jobs-homepage-grid .article-item a, .home .article-grid .article-item a, .home .article-grid .longer-reads .longer-reads-grid .article-item a, .home .article-grid .focus-on .focus-posts-grid .article-item a, .home .article-grid .jobs-homepage-grid .article-item a {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .home .focus-on.edp-bold-posts-4 .jobs-homepage-grid .article-item a, .home .focus-on.edp-bold-posts-3 .jobs-homepage-grid .article-item a, .home .focus-on.edp-bold-posts-2 .jobs-homepage-grid .article-item a, .home .longer-reads .jobs-homepage-grid .article-item a, .home .homepage-jobs .jobs-homepage-grid .article-item a, .home .article-grid .jobs-homepage-grid .article-item a {
+        align-items: flex-start;
+        justify-content: flex-start;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    body.single-post article.type-post .entry-footer .tag-links {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    body.single-post article.type-post .crp_related .article-grid .article-item a .tag-links {
+        flex-direction: column;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    body.single-post article.type-post .crp_related .article-grid .article-item a figure img, body.single-post article.type-post .crp_related .article-grid .article-item a .home-article-image img {
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    body.single-post article.type-post .crp_related .article-grid .article-item a figure, body.single-post article.type-post .crp_related .article-grid .article-item a .home-article-image {
+        width: 100%;
+        max-width: 320px;
+        margin-bottom: 0;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    body.single-post article.type-post .crp_related .article-grid .article-item a .crp_title {
+        width: 100%;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    body.single-post article.type-post .crp_related .article-grid .article-item a {
+        flex-direction: column;
+        gap: 0;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-events-community-details, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .tribe-section-content, .edpsybold .edpsybold.edp-jobs.add-job #container.edp-fullwidth .form-block, .edpsybold .category-jobs-admin .tribe-events-community-details, .edpsybold .category-jobs-admin .tribe-section-content, .edpsybold .category-jobs-admin .form-block, .edpsybold.tribe_community_edit .tribe-events-community-details, .edpsybold.tribe_community_edit .tribe-section-content, .edpsybold.tribe_community_edit .form-block {
+        padding: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .edpsybold input[type="text"], input[type="email"], input#create_account_email, input[type="password"], input#company_name, .fieldset-type-term-multiselect .field, .checkbox-pair {
+        max-width: none;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset .job-details-block .payment-details-name-description .field, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset .job-details-block .payment-details-name-description .job-listing {
+        text-align: left;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset .job-details-block .payment-details-name-description {
+        width: 100%;
+        justify-content: flex-start;
+        margin-bottom: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset .job-details-block {
+        flex-direction: column;
+        align-items: start;
+        margin-left: 0;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .fieldset-stripe_payment.fieldset-type-text .item-cost {
+        margin-left: 0;
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    body.single-post article.type-post .author-image-header-block .entry-meta .tags--header {
+        padding-right: 0;
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    body.single-post article.type-post .author-image-header-block .entry-meta .entry-meta--share-button {
+        margin-top: 0;
+        justify-content: start;
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    #signup-slice .signup-content .message h2 {
+        font-size: var(--fs-title-small);
+        line-height: var(--lh-title-small);
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    #signup-slice .signup-content {
+        padding: var(--sp-medium);
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    .home .article-grid .article-item a .article-item--image {
+        width: 100%;
+        max-width: none;
+        padding-right: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    .home section.hero-post h2, .home section.focus-on h2, .home section.longer-reads h2, .home section.homepage-events-wrapper h2, .home section.homepage-jobs-wrapper h2 {
+        font-size: var(--fs-title-medium);
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    .home section.hero-post h2, .home section.focus-on h2, .home section.longer-reads h2 {
+        margin-top: -48px;
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    .tribe_community_edit .datepicker.dropdown-menu, .tribe_community_edit div#ui-datepicker-div {
+        display: none !important;
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col1, .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form .option-col2 {
+        padding-right: var(--sp-small);
+        padding-left: var(--sp-small);
+    }
+}
+
+@media only screen and (max-width: 440px) {
+    .edpsybold.edp-jobs.add-job #container.edp-fullwidth .category-jobs-admin form#stripe-checkout-form fieldset {
+        padding-left: 0;
+    }
+}

--- a/functions.php
+++ b/functions.php
@@ -34,13 +34,51 @@ function edpsybold_notice_dismissed()
 add_action('wp_enqueue_scripts', 'edpsybold_enqueue');
 function edpsybold_enqueue()
 {
-    //  wp_enqueue_style('edpsybold-style', get_stylesheet_uri());
+    $template_directory = get_template_directory();
+    $template_uri = get_template_directory_uri();
+
+    $legacy_relative_path = '/css/edpsy-bold-style--legacy.css';
+    $modern_relative_path = '/css/edpsy-bold-style.css';
+
+    wp_enqueue_style(
+        'edpsy-bold-style-legacy',
+        $template_uri . $legacy_relative_path,
+        array(),
+        filemtime($template_directory . $legacy_relative_path)
+    );
+
     wp_enqueue_style(
         'edpsy-bold-style',
-        get_template_directory_uri() . '/css/edpsy-bold-style.css',
-        array(),
-        filemtime(get_template_directory() . '/css/edpsy-bold-style.css')
+        $template_uri . $modern_relative_path,
+        array('edpsy-bold-style-legacy'),
+        filemtime($template_directory . $modern_relative_path)
     );
+
+    wp_register_script('edpsybold-nesting-check', '', array(), null, false);
+    $nesting_check_script = "(function(){\n" .
+        "    var supportsNesting = false;\n" .
+        "    try {\n" .
+        "        supportsNesting = window.CSS && typeof window.CSS.supports === 'function' && window.CSS.supports('selector(&)');\n" .
+        "    } catch (error) {\n" .
+        "        supportsNesting = false;\n" .
+        "    }\n" .
+        "    var legacyStyle = document.getElementById('edpsy-bold-style-legacy-css');\n" .
+        "    var modernStyle = document.getElementById('edpsy-bold-style-css');\n" .
+        "    if (!legacyStyle) {\n" .
+        "        return;\n" .
+        "    }\n" .
+        "    if (supportsNesting) {\n" .
+        "        legacyStyle.setAttribute('media', 'not all');\n" .
+        "        if (modernStyle) {\n" .
+        "            modernStyle.setAttribute('media', 'all');\n" .
+        "        }\n" .
+        "    } else if (modernStyle) {\n" .
+        "        modernStyle.setAttribute('media', 'not all');\n" .
+        "    }\n" .
+        "})();";
+    wp_add_inline_script('edpsybold-nesting-check', $nesting_check_script);
+    wp_enqueue_script('edpsybold-nesting-check');
+
     wp_enqueue_script('jquery');
     wp_enqueue_script(
         'edpsybold-share',

--- a/scripts/build_legacy_css.py
+++ b/scripts/build_legacy_css.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+BASE_DIR = Path(__file__).resolve().parent.parent / "css"
+ENTRY_FILE = BASE_DIR / "edpsy-bold-style.css"
+LEGACY_FILE = BASE_DIR / "edpsy-bold-style--legacy.css"
+
+COMMENT_RE = re.compile(r"/\*[^*]*\*+(?:[^/*][^*]*\*+)*/", re.S)
+IMPORT_RE = re.compile(r"@import\s+url\(['\"]([^'\"]+)['\"]\)\s*;", re.I)
+CONTEXT_AT_RULES = {"@media", "@supports", "@layer", "@document"}
+
+
+def strip_comments(css: str) -> str:
+    return COMMENT_RE.sub("", css)
+
+
+def normalize_whitespace(css: str) -> str:
+    return css.replace("\r\n", "\n")
+
+
+def split_selector_list(selector: str) -> List[str]:
+    parts: List[str] = []
+    buf: List[str] = []
+    depth_round = depth_square = depth_curly = 0
+    in_string: str | None = None
+    i = 0
+    while i < len(selector):
+        ch = selector[i]
+        if in_string:
+            buf.append(ch)
+            if ch == in_string and selector[i - 1] != '\\':
+                in_string = None
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            buf.append(ch)
+            in_string = ch
+            i += 1
+            continue
+        if ch == '(':
+            depth_round += 1
+        elif ch == ')':
+            depth_round = max(depth_round - 1, 0)
+        elif ch == '[':
+            depth_square += 1
+        elif ch == ']':
+            depth_square = max(depth_square - 1, 0)
+        elif ch == '{':
+            depth_curly += 1
+        elif ch == '}':
+            depth_curly = max(depth_curly - 1, 0)
+        if ch == ',' and depth_round == depth_square == depth_curly == 0:
+            part = ''.join(buf).strip()
+            if part:
+                parts.append(part)
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    part = ''.join(buf).strip()
+    if part:
+        parts.append(part)
+    return parts
+
+
+def combine_selectors(parent: List[str], current: List[str]) -> List[str]:
+    if not parent:
+        return current
+    combined: List[str] = []
+    for p in parent:
+        for c in current:
+            if '&' in c:
+                combined.append(c.replace('&', p))
+            else:
+                stripped = c.strip()
+                if stripped.startswith((':', '::', '>', '+', '~')):
+                    combined.append(p + stripped)
+                else:
+                    combined.append(f"{p} {stripped}".strip())
+    return combined
+
+
+def read_block(css: str, start: int) -> Tuple[str, int]:
+    assert css[start] == '{'
+    depth = 1
+    i = start + 1
+    in_string: str | None = None
+    while i < len(css):
+        ch = css[i]
+        if in_string:
+            if ch == in_string and css[i - 1] != '\\':
+                in_string = None
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_string = ch
+            i += 1
+            continue
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                return css[start + 1:i], i + 1
+        i += 1
+    raise ValueError('Unclosed block')
+
+
+def skip_whitespace(css: str, start: int) -> int:
+    while start < len(css) and css[start] in ' \t\n\r':
+        start += 1
+    return start
+
+
+def read_until(css: str, start: int, stop_chars: str) -> Tuple[str, int]:
+    buf: List[str] = []
+    i = start
+    depth_round = depth_square = 0
+    in_string: str | None = None
+    while i < len(css):
+        ch = css[i]
+        if in_string:
+            buf.append(ch)
+            if ch == in_string and css[i - 1] != '\\':
+                in_string = None
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            buf.append(ch)
+            in_string = ch
+            i += 1
+            continue
+        if ch == '(':
+            depth_round += 1
+        elif ch == ')':
+            depth_round = max(depth_round - 1, 0)
+        elif ch == '[':
+            depth_square += 1
+        elif ch == ']':
+            depth_square = max(depth_square - 1, 0)
+        elif depth_round == depth_square == 0 and ch in stop_chars:
+            return ''.join(buf).strip(), i
+        buf.append(ch)
+        i += 1
+    return ''.join(buf).strip(), i
+
+
+def split_block_items(block: str):
+    items = []
+    i = 0
+    length = len(block)
+    while i < length:
+        i = skip_whitespace(block, i)
+        if i >= length:
+            break
+        if block[i] == '@':
+            prelude, pos = read_until(block, i, '{;')
+            if pos < length and block[pos] == ';':
+                items.append(('at-rule', prelude, None))
+                i = pos + 1
+            else:
+                inner, new_pos = read_block(block, pos)
+                items.append(('at-rule-block', prelude, inner))
+                i = new_pos
+            continue
+        token, pos = read_until(block, i, '{;')
+        if pos >= length:
+            break
+        if block[pos] == ';':
+            items.append(('decl', token.strip(), None))
+            i = pos + 1
+        else:
+            inner, new_pos = read_block(block, pos)
+            items.append(('rule', token.strip(), inner))
+            i = new_pos
+    return items
+
+
+def indent(text: str) -> str:
+    lines = text.split('\n')
+    return '\n'.join(('    ' + line if line else '') for line in lines)
+
+
+def wrap_with_at_stack(content: str, at_stack: List[str]) -> str:
+    wrapped = content
+    for at_rule in reversed(at_stack):
+        wrapped = f"{at_rule.strip()} {{\n{indent(wrapped)}\n}}"
+    return wrapped
+
+
+def emit_rule(selectors: List[str], declarations: List[str], at_stack: List[str], output: List[str]):
+    if not selectors or not declarations:
+        return
+    decl_lines = '\n'.join(f"    {decl.strip().rstrip(';')}" + ';' for decl in declarations)
+    rule_text = f"{', '.join(selectors)} {{\n{decl_lines}\n}}"
+    output.append(wrap_with_at_stack(rule_text, at_stack))
+
+
+def emit_at_rule(line: str, at_stack: List[str], output: List[str]):
+    text = f"{line.strip()};"
+    output.append(wrap_with_at_stack(text, at_stack))
+
+
+def emit_at_rule_block(token: str, inner: str, selectors: List[str], at_stack: List[str], output: List[str]):
+    rule_name = token.strip().split(None, 1)[0].lower()
+    if rule_name in CONTEXT_AT_RULES:
+        flatten_block(inner, selectors, at_stack + [token.strip()], output)
+    else:
+        block_text = f"{token.strip()} {{\n{indent(inner.strip())}\n}}"
+        output.append(wrap_with_at_stack(block_text, at_stack))
+
+
+def flatten_block(block: str, selectors: List[str], at_stack: List[str], output: List[str]):
+    declarations: List[str] = []
+    for kind, token, inner in split_block_items(block):
+        if kind == 'decl':
+            declarations.append(token)
+        elif kind == 'rule':
+            child_selectors = split_selector_list(token)
+            combined = combine_selectors(selectors, child_selectors)
+            flatten_block(inner, combined, at_stack, output)
+        elif kind == 'at-rule':
+            emit_at_rule(token, at_stack, output)
+        elif kind == 'at-rule-block':
+            emit_at_rule_block(token, inner, selectors, at_stack, output)
+    if declarations and selectors:
+        emit_rule(selectors, declarations, at_stack, output)
+
+
+def flatten_stylesheet(css: str, at_stack: List[str], output: List[str]):
+    i = 0
+    length = len(css)
+    while i < length:
+        i = skip_whitespace(css, i)
+        if i >= length:
+            break
+        if css[i] == '@':
+            prelude, pos = read_until(css, i, '{;')
+            if pos < length and css[pos] == ';':
+                output.append(wrap_with_at_stack(prelude.strip() + ';', at_stack))
+                i = pos + 1
+            else:
+                inner, new_pos = read_block(css, pos)
+                name = prelude.strip().split(None, 1)[0].lower()
+                if name in CONTEXT_AT_RULES:
+                    flatten_stylesheet(inner, at_stack + [prelude.strip()], output)
+                else:
+                    block_text = f"{prelude.strip()} {{\n{indent(inner.strip())}\n}}"
+                    output.append(wrap_with_at_stack(block_text, at_stack))
+                i = new_pos
+        else:
+            selector_text, pos = read_until(css, i, '{')
+            inner, new_pos = read_block(css, pos)
+            selectors = split_selector_list(selector_text.strip())
+            flatten_block(inner, selectors, at_stack, output)
+            i = new_pos
+
+
+def gather_sources(entry: Path) -> str:
+    combined: List[str] = []
+    fontawesome_imports: List[str] = []
+    seen: set[Path] = set()
+    seen_imports: set[str] = set()
+
+    def handle_file(path: Path):
+        if path in seen or not path.exists():
+            return
+        seen.add(path)
+        content = normalize_whitespace(path.read_text(encoding='utf-8'))
+        imports = list(IMPORT_RE.finditer(content))
+        body = IMPORT_RE.sub('', content)
+        for match in imports:
+            url = match.group(1)
+            if url.startswith('fontawesome'):
+                if url not in seen_imports:
+                    fontawesome_imports.append(f"@import url('{url}');")
+                    seen_imports.add(url)
+            else:
+                target = (path.parent / url).resolve()
+                handle_file(target)
+        combined.append(strip_comments(body))
+
+    handle_file(entry)
+    return '\n'.join(fontawesome_imports + combined)
+
+
+def main():
+    raw_css = gather_sources(ENTRY_FILE)
+    flattened: List[str] = []
+    flatten_stylesheet(raw_css, [], flattened)
+    output = '\n\n'.join(line for line in flattened if line.strip()) + '\n'
+    LEGACY_FILE.write_text(output, encoding='utf-8')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a Python utility to flatten the nested CSS bundle into a legacy stylesheet
- check the nested CSS support at runtime to toggle between the modern and legacy CSS files
- add the generated `edpsy-bold-style--legacy.css` for browsers without native nesting support

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68de77885f608325a05e428fc5f6b329