### PR TITLE
Display search term alongside clear search action

### DIFF
--- a/business-directory/main-box.tpl.php
+++ b/business-directory/main-box.tpl.php
@@ -63,11 +63,26 @@
 <?php
 // Show the "Clear search" link only when a search has been performed and we're on search results.
 $is_bd_search_view = isset($_GET['wpbdp_view']) && $_GET['wpbdp_view'] === 'search';
+$search_term       = '';
+
+if (isset($_GET['kw'])) {
+        $search_term = sanitize_text_field(wp_unslash($_GET['kw']));
+}
 
 if ((isset($searching) && $searching) || $is_bd_search_view):
-	?>
-	<p><a class="button edp-button-solid" href="<?php echo esc_url(wpbdp_get_page_link('main')); ?>">
-			<?php esc_html_e('Clear search', 'business-directory-plugin'); ?> <i class="far fa-times"></i>
-		</a></p>
+        ?>
+        <div class="wpbdp-search-actions">
+                <?php if ($search_term): ?>
+                        <p class="wpbdp-search-term">
+                                <span class="wpbdp-search-term__label"><?php esc_html_e('Search term:', 'business-directory-plugin'); ?></span>
+                                <span class="wpbdp-search-term__value">&ldquo;<?php echo esc_html($search_term); ?>&rdquo;</span>
+                        </p>
+                <?php endif; ?>
+                <p class="wpbdp-search-reset">
+                        <a class="button edp-button-solid" href="<?php echo esc_url(wpbdp_get_page_link('main')); ?>">
+                                <?php esc_html_e('Clear search', 'business-directory-plugin'); ?> <i class="far fa-times"></i>
+                        </a>
+                </p>
+        </div>
 <?php endif; ?>
 <!-- file end: business-directory/main-box.tpl.php-->


### PR DESCRIPTION
## Summary
- surface the keyword that was searched when displaying the search results controls
- keep the clear search action and group it with the new search term summary

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e27ff0b30c83259cd0f0ae298648d6