### PR TITLE
Add AJAX post search controls to homepage customizer

### DIFF
--- a/css/customizer-post-search.css
+++ b/css/customizer-post-search.css
@@ -1,0 +1,76 @@
+.edp-post-search {
+    position: relative;
+}
+
+.edp-post-search__input {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.edp-post-search__results {
+    display: none;
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    max-height: 240px;
+    overflow-y: auto;
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    padding: 8px 0;
+}
+
+.edp-post-search__results.is-open {
+    display: block;
+}
+
+.edp-post-search__results.is-loading::after {
+    content: '';
+    display: block;
+    width: 24px;
+    height: 24px;
+    margin: 0 auto;
+    border: 3px solid #ccd0d4;
+    border-top-color: #007cba;
+    border-radius: 50%;
+    animation: edp-post-search-spin 1s linear infinite;
+}
+
+.edp-post-search__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.edp-post-search__item {
+    display: block;
+    width: 100%;
+    padding: 8px 12px;
+    background: transparent;
+    border: 0;
+    text-align: left;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.edp-post-search__item:hover,
+.edp-post-search__item:focus {
+    background-color: #f0f0f1;
+}
+
+.edp-post-search__message {
+    padding: 8px 12px;
+    font-size: 13px;
+    color: #50575e;
+}
+
+@keyframes edp-post-search-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/functions.php
+++ b/functions.php
@@ -312,6 +312,177 @@ add_filter('body_class', 'edpsy_add_parent_page_body_class');
 
 // ======== Customizer - featured post
 
+if (class_exists('WP_Customize_Control') && !class_exists('Edp_Post_Search_Customize_Control')) {
+    class Edp_Post_Search_Customize_Control extends WP_Customize_Control
+    {
+        public $type = 'edp_post_search';
+
+        public $post_type = 'post';
+
+        public $filters = array();
+
+        public $placeholder = '';
+
+        public function to_json()
+        {
+            parent::to_json();
+            $this->json['post_type'] = $this->post_type;
+            $this->json['filters']   = $this->filters;
+            $this->json['placeholder'] = $this->placeholder;
+            $this->json['selected'] = $this->get_selected_post();
+        }
+
+        protected function get_selected_post()
+        {
+            $post_id = absint($this->value());
+
+            if (!$post_id) {
+                return array(
+                    'id'    => 0,
+                    'title' => '',
+                );
+            }
+
+            $post = get_post($post_id);
+
+            if (!$post instanceof WP_Post) {
+                return array(
+                    'id'    => 0,
+                    'title' => '',
+                );
+            }
+
+            return array(
+                'id'    => $post_id,
+                'title' => get_the_title($post),
+            );
+        }
+
+        public function render_content()
+        {
+            if ($this->label) {
+                echo '<span class="customize-control-title">' . esc_html($this->label) . '</span>';
+            }
+
+            if ($this->description) {
+                echo '<span class="description customize-control-description">' . esc_html($this->description) . '</span>';
+            }
+
+            $selected = $this->get_selected_post();
+            ?>
+            <div class="edp-post-search" data-post-type="<?php echo esc_attr($this->post_type); ?>" data-filters="<?php echo esc_attr(wp_json_encode($this->filters)); ?>">
+                <input type="search" class="edp-post-search__input" value="<?php echo esc_attr($selected['title']); ?>" placeholder="<?php echo esc_attr($this->placeholder); ?>" autocomplete="off">
+                <input type="hidden" class="edp-post-search__value" <?php $this->link(); ?> value="<?php echo esc_attr($selected['id']); ?>">
+                <div class="edp-post-search__results" aria-live="polite"></div>
+            </div>
+            <?php
+        }
+    }
+}
+
+function edp_enqueue_customizer_assets()
+{
+    $script_path = get_template_directory() . '/js/customizer-post-search.js';
+    $style_path  = get_template_directory() . '/css/customizer-post-search.css';
+
+    $script_version = file_exists($script_path) ? filemtime($script_path) : '1.0.0';
+    $style_version  = file_exists($style_path) ? filemtime($style_path) : '1.0.0';
+
+    wp_enqueue_script(
+        'edp-customizer-post-search',
+        get_template_directory_uri() . '/js/customizer-post-search.js',
+        array('customize-controls', 'wp-util', 'jquery'),
+        $script_version,
+        true
+    );
+
+    wp_localize_script(
+        'edp-customizer-post-search',
+        'edpPostSearch',
+        array(
+            'nonce' => wp_create_nonce('edp_search_posts'),
+            'noResults' => __('No matching posts found.', 'mytheme'),
+            'selectPrompt' => __('Select a tag to choose posts.', 'mytheme'),
+        )
+    );
+
+    wp_enqueue_style(
+        'edp-customizer-post-search',
+        get_template_directory_uri() . '/css/customizer-post-search.css',
+        array(),
+        $style_version
+    );
+}
+add_action('customize_controls_enqueue_scripts', 'edp_enqueue_customizer_assets');
+
+function edp_ajax_search_posts()
+{
+    if (!current_user_can('edit_theme_options')) {
+        wp_send_json_error(__('You are not allowed to perform this action.', 'mytheme'), 403);
+    }
+
+    check_ajax_referer('edp_search_posts', 'nonce');
+
+    $post_type = isset($_POST['post_type']) ? sanitize_key(wp_unslash($_POST['post_type'])) : 'post';
+    $search_query = isset($_POST['query']) ? sanitize_text_field(wp_unslash($_POST['query'])) : '';
+
+    $args = array(
+        'post_type'      => $post_type,
+        'post_status'    => 'publish',
+        'posts_per_page' => 20,
+        'orderby'        => 'date',
+        'order'          => 'DESC',
+        'no_found_rows'  => true,
+    );
+
+    if ('' !== $search_query) {
+        $args['s'] = $search_query;
+    }
+
+    $tax_query = array();
+
+    if (!empty($_POST['tag_id'])) {
+        $tax_query[] = array(
+            'taxonomy' => 'post_tag',
+            'field'    => 'term_id',
+            'terms'    => absint(wp_unslash($_POST['tag_id'])),
+        );
+    }
+
+    if (!empty($_POST['category'])) {
+        $tax_query[] = array(
+            'taxonomy' => 'category',
+            'field'    => 'slug',
+            'terms'    => sanitize_title(wp_unslash($_POST['category'])),
+        );
+    }
+
+    if (!empty($tax_query)) {
+        $args['tax_query'] = $tax_query;
+    }
+
+    $posts = new WP_Query($args);
+    $results = array();
+
+    if ($posts->have_posts()) {
+        foreach ($posts->posts as $post) {
+            if (!$post instanceof WP_Post) {
+                continue;
+            }
+
+            $results[] = array(
+                'id'    => $post->ID,
+                'title' => get_the_title($post),
+            );
+        }
+    }
+
+    wp_reset_postdata();
+
+    wp_send_json_success($results);
+}
+add_action('wp_ajax_edp_search_posts', 'edp_ajax_search_posts');
+
 function mytheme_customize_register($wp_customize)
 {
     // Add a section for the Hero Post
@@ -320,13 +491,6 @@ function mytheme_customize_register($wp_customize)
         'priority' => 30,
     ));
 
-    // Get all posts for the dropdown
-    $posts = get_posts(array('numberposts' => -1));
-    $choices = array('' => '— Select a post —');
-    foreach ($posts as $post) {
-        $choices[$post->ID] = $post->post_title;
-    }
-
     // Add the setting
     $wp_customize->add_setting('hero_post_id', array(
         'default' => '',
@@ -334,13 +498,13 @@ function mytheme_customize_register($wp_customize)
     ));
 
     // Add the control
-    $wp_customize->add_control('hero_post_id', array(
+    $wp_customize->add_control(new Edp_Post_Search_Customize_Control($wp_customize, 'hero_post_id', array(
         'label' => __('Select Hero Post', 'mytheme'),
         'section' => 'edp_home_section',
         'settings' => 'hero_post_id',
-        'type' => 'select',
-        'choices' => $choices,
-    ));
+        'post_type' => 'post',
+        'placeholder' => __('Search for a post…', 'mytheme'),
+    )));
 }
 add_action('customize_register', 'mytheme_customize_register');
 
@@ -393,28 +557,21 @@ function edp_customize_register($wp_customize)
         'choices' => $tag_choices,
     ));
 
-    // Prepare post choices once (outside the loop)
-    $post_choices = array('' => '— Select a post —');
-    $posts = get_posts(array(
-        'numberposts' => 100,
-        'post_status' => 'publish',
-    ));
-    foreach ($posts as $post) {
-        $post_choices[$post->ID] = $post->post_title;
-    }
-
     // Add Focus On post selectors
     for ($i = 1; $i <= 4; $i++) {
         $wp_customize->add_setting("focus_on_post_$i", array(
             'default' => '',
             'sanitize_callback' => 'absint',
         ));
-        $wp_customize->add_control("focus_on_post_$i", array(
+        $wp_customize->add_control(new Edp_Post_Search_Customize_Control($wp_customize, "focus_on_post_$i", array(
             'label' => __("Focus On Post $i", 'yourtheme'),
             'section' => $section,
-            'type' => 'select',
-            'choices' => $post_choices,
-        ));
+            'post_type' => 'post',
+            'filters' => array(
+                'tagSetting' => 'focus_on_tag',
+            ),
+            'placeholder' => __('Search for a tagged post…', 'yourtheme'),
+        )));
     }
 
     // ===== Longer Reads Section =====
@@ -447,12 +604,15 @@ function edp_customize_register($wp_customize)
             'default' => '',
             'sanitize_callback' => 'absint',
         ));
-        $wp_customize->add_control("longer_reads_post_$i", array(
+        $wp_customize->add_control(new Edp_Post_Search_Customize_Control($wp_customize, "longer_reads_post_$i", array(
             'label' => __("Longer Read Post $i", 'yourtheme'),
             'section' => $section,
-            'type' => 'select',
-            'choices' => $post_choices,
-        ));
+            'post_type' => 'post',
+            'filters' => array(
+                'category' => 'features',
+            ),
+            'placeholder' => __('Search feature posts…', 'yourtheme'),
+        )));
     }
 }
 add_action('customize_register', 'edp_customize_register');

--- a/js/customizer-post-search.js
+++ b/js/customizer-post-search.js
@@ -1,0 +1,199 @@
+(function ($, api) {
+    'use strict';
+
+    var debounce = function (fn, delay) {
+        var timer = null;
+        return function () {
+            var context = this;
+            var args = arguments;
+            window.clearTimeout(timer);
+            timer = window.setTimeout(function () {
+                fn.apply(context, args);
+            }, delay);
+        };
+    };
+
+    api.controlConstructor.edp_post_search = api.Control.extend({
+        ready: function () {
+            var control = this;
+
+            control.input = control.container.find('.edp-post-search__input');
+            control.valueField = control.container.find('.edp-post-search__value');
+            control.results = control.container.find('.edp-post-search__results');
+            control.postType = control.params.post_type || 'post';
+            control.filters = control.params.filters || {};
+            control.placeholder = control.params.placeholder || '';
+            control.requestToken = 0;
+
+            control.bindEvents();
+            control.maybeBindTagWatcher();
+        },
+
+        bindEvents: function () {
+            var control = this;
+
+            control.input.on('input', debounce(function () {
+                control.search(control.input.val());
+            }, 200));
+
+            control.input.on('focus', function () {
+                control.search(control.input.val());
+            });
+
+            control.results.on('click', '.edp-post-search__item', function (event) {
+                event.preventDefault();
+                var button = $(this);
+                control.selectPost(button.data('postId'), button.data('postTitle'));
+            });
+
+            $(document).on('click', function (event) {
+                if (!control.container.is(event.target) && !control.container.has(event.target).length) {
+                    control.closeResults();
+                }
+            });
+        },
+
+        maybeBindTagWatcher: function () {
+            var control = this;
+
+            if (!control.filters.tagSetting) {
+                return;
+            }
+
+            api(control.filters.tagSetting, function (setting) {
+                setting.bind(function (value) {
+                    if (!value) {
+                        control.clearSelection();
+                    }
+
+                    control.search(control.input.val());
+                });
+            });
+        },
+
+        closeResults: function () {
+            this.results.removeClass('is-open is-loading');
+            this.results.empty();
+        },
+
+        clearSelection: function () {
+            this.valueField.val('').trigger('change');
+            this.input.val('');
+            if (this.setting) {
+                this.setting.set(0);
+            }
+        },
+
+        selectPost: function (postId, postTitle) {
+            var id = parseInt(postId, 10);
+
+            if (isNaN(id)) {
+                id = 0;
+            }
+
+            this.valueField.val(id).trigger('change');
+            this.input.val(postTitle);
+            if (this.setting) {
+                this.setting.set(id);
+            }
+            this.closeResults();
+        },
+
+        getTagId: function () {
+            if (!this.filters.tagSetting) {
+                return 0;
+            }
+
+            var setting = api(this.filters.tagSetting);
+            if (!setting) {
+                return 0;
+            }
+
+            var value = parseInt(setting.get(), 10);
+            if (isNaN(value)) {
+                return 0;
+            }
+
+            return value;
+        },
+
+        search: function (query) {
+            var control = this;
+            var currentQuery = query;
+
+            if (typeof currentQuery !== 'string') {
+                currentQuery = currentQuery === undefined || currentQuery === null ? '' : String(currentQuery);
+            }
+
+            var requestArgs = {
+                nonce: edpPostSearch.nonce,
+                post_type: control.postType,
+                query: currentQuery
+            };
+
+            if (control.filters.category) {
+                requestArgs.category = control.filters.category;
+            }
+
+            if (control.filters.tagSetting) {
+                var tagId = control.getTagId();
+                if (!tagId) {
+                    control.showMessage(edpPostSearch.selectPrompt);
+                    return;
+                }
+
+                requestArgs.tag_id = tagId;
+            }
+
+            control.results.addClass('is-open is-loading');
+            control.results.empty();
+
+            var token = ++control.requestToken;
+
+            wp.ajax.post('edp_search_posts', requestArgs).done(function (response) {
+                if (token !== control.requestToken) {
+                    return;
+                }
+
+                control.renderResults(response);
+            }).fail(function () {
+                if (token !== control.requestToken) {
+                    return;
+                }
+
+                control.showMessage(edpPostSearch.noResults);
+            });
+        },
+
+        renderResults: function (items) {
+            this.results.removeClass('is-loading');
+            this.results.empty();
+
+            if (!items || !items.length) {
+                this.showMessage(edpPostSearch.noResults);
+                return;
+            }
+
+            var list = $('<ul />').addClass('edp-post-search__list');
+
+            items.forEach(function (item) {
+                var button = $('<button type="button" />')
+                    .addClass('edp-post-search__item')
+                    .data('postId', item.id)
+                    .data('postTitle', item.title)
+                    .text(item.title);
+
+                var listItem = $('<li />').append(button);
+                list.append(listItem);
+            });
+
+            this.results.append(list);
+        },
+
+        showMessage: function (message) {
+            this.results.removeClass('is-loading');
+            this.results.addClass('is-open');
+            this.results.html($('<div />').addClass('edp-post-search__message').text(message));
+        }
+    });
+})(jQuery, wp.customize);


### PR DESCRIPTION
## Summary
- replace dropdown post selectors with a reusable Customizer control that supports live searching
- add a secure AJAX endpoint plus JS and styles to provide filtered suggestions for hero, focus on, and longer read slots

## Testing
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e3e4623558832580eef18d65bcb384